### PR TITLE
fix(db): alias events_resolved AS events in funnel + conversion queries

### DIFF
--- a/packages/db/src/services/conversion.service.ts
+++ b/packages/db/src/services/conversion.service.ts
@@ -153,7 +153,7 @@ export class ConversionService {
             ${conditionA},
             ${conditionB}
           ) as steps
-        FROM ${TABLE_NAMES.eventsRead}
+        FROM ${TABLE_NAMES.eventsRead} AS events
         ${profileJoin}
         ${groupJoin}
         ${cohortJoinsSql}

--- a/packages/db/src/services/funnel-sql.test.ts
+++ b/packages/db/src/services/funnel-sql.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { IChartEvent } from '@openpanel/validation';
+
+const eventSeries: IChartEvent[] = [
+  {
+    id: '1',
+    name: 'sign_up',
+    displayName: 'sign_up',
+    segment: 'event',
+    filters: [],
+  },
+  {
+    id: '2',
+    name: 'purchase',
+    displayName: 'purchase',
+    segment: 'event',
+    filters: [],
+  },
+];
+
+function buildFunnelSql(funnelService: any): string {
+  return funnelService
+    .buildFunnelCte({
+      projectId: 'p1',
+      startDate: '2026-06-01 00:00:00',
+      endDate: '2026-06-02 00:00:00',
+      eventSeries,
+      funnelWindowMilliseconds: 86_400_000,
+      timezone: 'UTC',
+    })
+    .toSQL();
+}
+
+// The funnel CTE qualifies columns as `events.*` (conditions, name filter,
+// profile/cohort joins), so whatever table eventsRead points at must be
+// aliased AS events — otherwise ClickHouse fails with UNKNOWN_IDENTIFIER.
+describe('funnel CTE events alias', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('aliases events_resolved AS events when NEWTON_RESOLVE_PROFILE=1', async () => {
+    vi.stubEnv('NEWTON_RESOLVE_PROFILE', '1');
+    const { funnelService } = await import('./funnel.service');
+    const sql = buildFunnelSql(funnelService);
+    expect(sql).toContain('events.name');
+    expect(sql).toContain('FROM events_resolved AS events');
+  });
+
+  it('keeps the events alias when the flag is off', async () => {
+    vi.stubEnv('NEWTON_RESOLVE_PROFILE', '');
+    const { funnelService } = await import('./funnel.service');
+    const sql = buildFunnelSql(funnelService);
+    expect(sql).toContain('FROM events AS events');
+  });
+});

--- a/packages/db/src/services/funnel.service.ts
+++ b/packages/db/src/services/funnel.service.ts
@@ -90,7 +90,9 @@ export class FunnelService {
       // Newton fork: read from the resolution view so anonymous (pre-login)
       // events fold into the identified profile for funnel grouping. Inert
       // unless NEWTON_RESOLVE_PROFILE=1 (eventsRead === events otherwise).
-      .from(TABLE_NAMES.eventsRead, false)
+      // Must keep the `events` alias: funnel conditions, the name filter and
+      // the profile/cohort joins all qualify columns as `events.*`.
+      .from(`${TABLE_NAMES.eventsRead} AS events`, false)
       .where('project_id', '=', projectId)
       .where('created_at', 'BETWEEN', [
         clix.datetime(startDate, 'toDateTime'),


### PR DESCRIPTION
## Summary
- Production funnels are all failing with ClickHouse error 47: ``Unknown expression or function identifier `events.name` in scope session_funnel`` (tRPC path `chart.funnel`).
- Root cause: 72fc6dd3 swapped the funnel/conversion `FROM` to `TABLE_NAMES.eventsRead`, which is the `events_resolved` view in production (`NEWTON_RESOLVE_PROFILE=1`), while the query bodies still qualify columns as `events.*` — the windowFunnel step conditions, the `events.name IN (...)` filter, and the profile/cohort joins. With no `events` identifier in scope, every funnel query fails at parse time. `conversion.service.ts` has the identical latent break (no errors logged yet only because no one has loaded a conversion chart).
- Fix: alias the read table `AS events` in both services, matching the pattern `retention.service.ts` already uses. Inert when the flag is off (`events AS events`), and the view exposes every events column, so all qualified references resolve.

## Changes
- `packages/db/src/services/funnel.service.ts` — `.from(`${TABLE_NAMES.eventsRead} AS events`, false)` in the funnel CTE
- `packages/db/src/services/conversion.service.ts` — `FROM ${TABLE_NAMES.eventsRead} AS events` in the windowFunnel subquery
- `packages/db/src/services/funnel-sql.test.ts` — new test asserting the alias renders in both flag states

## Test plan
- [x] New test is red on the pre-fix code, green with the fix
- [x] Reproduced the exact production error locally (Docker ClickHouse + `events_resolved` view + `device_alias` dictionary per the migration-16 runbook) on the unfixed code
- [x] Executed the real `getFunnel` and `getConversion` paths with `NEWTON_RESOLVE_PROFILE=1` against the fixed code — both run clean
- [x] Full `packages/db` suite passes (32/32)
- [x] Typecheck: 0 errors in changed files (22 pre-existing errors elsewhere, untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)