### PR TITLE
perf(worker): stop full-scanning events on every sessions job

### DIFF
--- a/apps/worker/src/jobs/sessions.ts
+++ b/apps/worker/src/jobs/sessions.ts
@@ -41,8 +41,14 @@ const updateEventsCount = cacheable(async function updateEventsCount(
     return;
   }
 
-  const organizationEventsCount =
-    await getOrganizationBillingEventsCount(organization);
+  // Newton: billing/usage tracking disabled for self-hosted personal use — getOrganization
+  // BillingEventsCount full-scans events for the subscription period on every fire and we
+  // don't bill. Project eventsCount is kept (now a cheap distinct_event_names_mv pre-agg read).
+  // biome-ignore lint/correctness/noConstantCondition: feature flag, original path preserved
+  const BILLING_ENABLED = false;
+  const organizationEventsCount = BILLING_ENABLED
+    ? await getOrganizationBillingEventsCount(organization)
+    : 0;
   const projectEventsCount = await getProjectEventsCount(projectId);
 
   if (projectEventsCount) {
@@ -56,7 +62,7 @@ const updateEventsCount = cacheable(async function updateEventsCount(
     });
   }
 
-  if (organizationEventsCount) {
+  if (BILLING_ENABLED && organizationEventsCount) {
     await db.organization.update({
       where: {
         id: organization.id,

--- a/packages/db/src/services/project.service.ts
+++ b/packages/db/src/services/project.service.ts
@@ -93,8 +93,19 @@ export async function getProjects({
 }
 
 export const getProjectEventsCount = async (projectId: string) => {
+  // Newton: `name NOT IN (...)` is a negation, so it can't use idx_name and this
+  // full-scanned the whole project on every sessions-job fire (~2.9B rows after the
+  // Mixpanel import). distinct_event_names_mv already holds `count() AS event_count`
+  // per (project_id, name), so summing it returns the same total from a tiny pre-aggregate.
+  // biome-ignore lint/correctness/noConstantCondition: original full-scan kept (disabled) for easy revert
+  if (false) {
+    const res = await chQuery<{ count: number }>(
+      `SELECT count(*) as count FROM ${TABLE_NAMES.events} WHERE project_id = ${sqlstring.escape(projectId)} AND name NOT IN ('session_start', 'session_end')`
+    );
+    return res[0]?.count;
+  }
   const res = await chQuery<{ count: number }>(
-    `SELECT count(*) as count FROM ${TABLE_NAMES.events} WHERE project_id = ${sqlstring.escape(projectId)} AND name NOT IN ('session_start', 'session_end')`
+    `SELECT sum(event_count) as count FROM ${TABLE_NAMES.event_names_mv} WHERE project_id = ${sqlstring.escape(projectId)} AND name NOT IN ('session_start', 'session_end')`
   );
   return res[0]?.count;
 };


### PR DESCRIPTION
## Problem

The `sessions` worker job (`apps/worker/src/jobs/sessions.ts`) recomputes project + org event counts on every fire (debounced via `cacheable`, 1h TTL). Both counts use:

```sql
count(*) ... WHERE project_id = ? AND name NOT IN ('session_start','session_end')
```

`name NOT IN (...)` is a **negation**, so it can't use the `idx_name` bloom filter, and `project_id` matches ~the whole table → each runs a **full project scan**. After backfilling ~2.9B historical (Mixpanel) events into the ingestion ClickHouse, this became a ~2.9B-row scan per fire (~295 MiB, ~1.3s each, ×~1,700) and pinned the ingestion CH — it autoscaled **2 → 59 vCPU**.

## Changes (surgical; originals preserved behind flags for easy revert)

1. **`getProjectEventsCount`** → read the existing **`distinct_event_names_mv`** (`count() AS event_count` per `(project_id, name)`) and `sum(event_count)` instead of scanning `events`. Same total, from a tiny pre-aggregate (thousands of rows vs ~2.9B). Original full-scan kept behind `if (false)`.
2. **Billing count** → gated behind `BILLING_ENABLED = false` in the sessions job (self-hosted, no billing). Skips `getOrganizationBillingEventsCount` (the period full-scan) + the subscription-limit update. Original path preserved behind the flag.

No schema change. `project.eventsCount` is still updated (now cheaply). `cacheable` TTL left at 1h (unchanged — no side effects).

## Notes
- `distinct_event_names_mv` (and the direct count) are currently inflated by duplicate rows in the Mixpanel raw export; that's handled separately by a dedup pass. This PR only changes *where* the count is read from, not its value.
- Re-enable either path by flipping `if (false)` / `BILLING_ENABLED`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)