### PR TITLE
fix(db): funnel breakdown shows 0 on later steps when breakdown property is step-specific

### DIFF
--- a/packages/db/src/services/funnel.service.ts
+++ b/packages/db/src/services/funnel.service.ts
@@ -260,12 +260,29 @@ export class FunnelService {
     const cohortMetadata = await fetchCohortsMetadata(cohortIds);
 
     // Create the funnel CTE (session-level)
+    //
+    // Newton fork: attribute each breakdown to the value at the FIRST funnel
+    // step, as a per-group aggregate (argMinIf) — do NOT add it to the
+    // windowFunnel GROUP BY. Grouping the sequence by a per-row property splits
+    // a user's steps across buckets whenever the property isn't identical on
+    // every step (e.g. an experiment `cohort` set on `experiment_started` but
+    // absent on `paid`): the later step lands in a separate (empty) bucket, the
+    // windowFunnel sequence never connects, and downstream steps show 0. Reading
+    // the entry-step value keeps each user's sequence intact in one group and
+    // matches standard funnel-breakdown semantics (segment by entry attribute).
+    const funnelConditions = this.getFunnelConditions(eventSeries, projectId);
+    const firstStepCondition = funnelConditions[0]!;
     const breakdownSelects = breakdowns.map((b, index) => {
       const bId = extractCohortId(b.name);
       const bName = bId ? cohortMetadata.get(bId)?.name : undefined;
-      return `${getSelectPropertyKey(b.name, projectId, bId ?? undefined, bName)} as b_${index}`;
+      const expr = getSelectPropertyKey(
+        b.name,
+        projectId,
+        bId ?? undefined,
+        bName,
+      );
+      return `argMinIf(${expr}, created_at, ${firstStepCondition}) as b_${index}`;
     });
-    const breakdownGroupBy = breakdowns.map((b, index) => `b_${index}`);
 
     const funnelCte = this.buildFunnelCte({
       projectId,
@@ -275,7 +292,6 @@ export class FunnelService {
       funnelWindowMilliseconds,
       timezone,
       additionalSelects: breakdownSelects,
-      additionalGroupBy: breakdownGroupBy,
       group,
     });
 


### PR DESCRIPTION
## Problem
Reported by Arshiya on the *Timeline Payment Page* funnel report: with a **breakdown** on \`cohort\`, step 1 (\`experiment_started\`) splits correctly into variant/control but step 2 (\`paid\`) shows **0** in every bucket. Remove the breakdown and \`paid\` is correct.

## Root cause
The funnel puts the breakdown in the \`windowFunnel\` **GROUP BY** (\`GROUP BY session_id, b_0\`). \`b_0\` is read **per event row**. The breakdown here (\`cohort\`) is set on \`experiment_started\` (the variant assignment) but **absent on \`paid\`**. So a converting user's two events split into different groups — \`(session,'variant')\` holds only step 1, \`(session,'')\` holds only the paid row — and \`windowFunnel(strict_increase)\` can't connect the sequence. Every broken-down bucket tops out at level 1.

This is upstream OpenPanel funnel logic (not from our recent fork changes). It's correct only when the breakdown is user-stable (profile props, super-properties); it breaks for event-property breakdowns that aren't present on every step. It also **double-counts** step 1 for sessions that started multiple experiments.

## Fix
Attribute each breakdown to the value at the **first funnel step** as a per-group aggregate — \`argMinIf(expr, created_at, firstStepCondition)\` — and remove it from the \`GROUP BY\`. \`windowFunnel\` then runs over each user's intact sequence, and each user is bucketed once (standard Mixpanel/PostHog funnel-breakdown semantics: segment by entry attribute). Users with no value at entry fall into "Not set" but still flow through.

Scope: one function (\`FunnelService.getFunnel\` / breakdown selects). Profile- and cohort-property breakdowns are unaffected (constant per session).

## Validation (prod, WelcomeMobileExperienceV1 → NSAT-fee paid, breakdown cohort, 7d)
| | level 1 | level 2 (paid) |
|---|---|---|
| no breakdown (anchor) | 1380 | **35** |
| buggy (group by session_id, cohort) | 1416 ⚠️ | **0** |
| fixed (cohort from entry step) | **1380** ✓ | variant 24 + control 11 = **35** ✓ |

Fixed buckets partition cleanly and reconcile exactly with the no-breakdown totals.