### PR TITLE
perf(ch): event_property_values_mv projections for property dropdowns

### DIFF
--- a/packages/db/code-migrations/16-event-property-values-projections.ts
+++ b/packages/db/code-migrations/16-event-property-values-projections.ts
@@ -1,0 +1,123 @@
+import { TABLE_NAMES } from '../src/clickhouse/client';
+import {
+  chMigrationClient,
+  runClickhouseMigrationCommands,
+} from '../src/clickhouse/migration';
+import { getIsCluster } from './helpers';
+
+/**
+ * Perf: the property-key / property-value autocompletes scanned the ENTIRE
+ * event_property_values_mv (1.57B rows on Newton prod after the Mixpanel import)
+ * just to return ~6.4K distinct keys. The MV is
+ * ORDER BY (project_id, name, property_key, property_value), so the project-wide
+ * `SELECT DISTINCT property_key ... GROUP BY property_key` (no `name` filter)
+ * can't seek and full-scans; `... WHERE property_key=? GROUP BY property_value`
+ * likewise can't seek on property_key (it's behind `name`).
+ *
+ * Two aggregating projections let those queries read a few thousand rows:
+ *   epv_keys   -> (project_id, property_key)                 max(created_at)
+ *   epv_values -> (project_id, property_key, property_value) max(created_at)
+ * The query optimizer rewrites the dropdown queries transparently (no app change).
+ *
+ * SharedAggregatingMergeTree refuses ADD PROJECTION while
+ * deduplicate_merge_projection_mode = 'throw' (the default); 'rebuild' keeps the
+ * projection correct across dedup-merges.
+ *
+ * Idempotent: ADD ... IF NOT EXISTS, and MATERIALIZE is skipped where the
+ * projection already has active parts — so it's a no-op on Newton prod (first
+ * applied by hand) and instant on a fresh/empty MV.
+ */
+
+const MV = TABLE_NAMES.event_property_values_mv;
+
+const PROJECTIONS = [
+  {
+    name: 'epv_keys',
+    def: 'SELECT project_id, property_key, max(created_at) AS created_at GROUP BY project_id, property_key',
+  },
+  {
+    name: 'epv_values',
+    def: 'SELECT project_id, property_key, property_value, max(created_at) AS created_at GROUP BY project_id, property_key, property_value',
+  },
+];
+
+async function jsonRows<T>(query: string): Promise<T[]> {
+  const res = await chMigrationClient.query({ query, format: 'JSONEachRow' });
+  return res.json<T>();
+}
+
+// The projection lives on the MV's STORAGE table: the implicit inner table
+// (`.inner_id.<uuid>`) on a single node, or `<mv>_replicated` when clustered.
+async function resolveStorageTable(isClustered: boolean): Promise<string> {
+  if (isClustered) {
+    return `${MV}_replicated`;
+  }
+  const rows = await jsonRows<{ t: string }>(
+    `SELECT concat('.inner_id.', toString(uuid)) AS t
+     FROM system.tables WHERE database = currentDatabase() AND name = '${MV}'`,
+  );
+  if (!rows[0]?.t) {
+    throw new Error(`${MV}: inner storage table not found`);
+  }
+  return rows[0].t;
+}
+
+async function projectionHasParts(
+  storage: string,
+  projection: string,
+): Promise<boolean> {
+  const rows = await jsonRows<{ c: string }>(
+    `SELECT count() AS c FROM system.projection_parts
+     WHERE database = currentDatabase()
+       AND table = '${storage.replace(/'/g, "''")}'
+       AND name = '${projection}'
+       AND active`,
+  );
+  return Number(rows[0]?.c ?? 0) > 0;
+}
+
+export async function up() {
+  const isClustered = getIsCluster();
+  const storage = await resolveStorageTable(isClustered);
+  const tbl = `\`${storage}\``;
+  const onCluster = isClustered ? " ON CLUSTER '{cluster}'" : '';
+
+  const ddl = [
+    `ALTER TABLE ${tbl}${onCluster} MODIFY SETTING deduplicate_merge_projection_mode = 'rebuild'`,
+    ...PROJECTIONS.map(
+      (p) =>
+        `ALTER TABLE ${tbl}${onCluster} ADD PROJECTION IF NOT EXISTS ${p.name} (${p.def})`,
+    ),
+  ];
+
+  if (process.argv.includes('--dry')) {
+    console.log(ddl.join(';\n'));
+    return;
+  }
+
+  await runClickhouseMigrationCommands(ddl);
+
+  // Backfill the projections into existing parts. Guarded so we don't re-scan
+  // 1.57B rows where the projection is already materialized.
+  for (const p of PROJECTIONS) {
+    if (await projectionHasParts(storage, p.name)) {
+      console.log(`[16] projection ${p.name} already materialized — skipping`);
+      continue;
+    }
+    await runClickhouseMigrationCommands([
+      `ALTER TABLE ${tbl}${onCluster} MATERIALIZE PROJECTION ${p.name}`,
+    ]);
+  }
+}
+
+export async function down() {
+  const isClustered = getIsCluster();
+  const storage = await resolveStorageTable(isClustered);
+  const tbl = `\`${storage}\``;
+  const onCluster = isClustered ? " ON CLUSTER '{cluster}'" : '';
+  await runClickhouseMigrationCommands(
+    PROJECTIONS.map(
+      (p) => `ALTER TABLE ${tbl}${onCluster} DROP PROJECTION IF EXISTS ${p.name}`,
+    ),
+  );
+}


### PR DESCRIPTION
## Problem

After the Mixpanel→OpenPanel historical import, the dashboard (on a ClickHouse read-replica) slowed sharply. The single heaviest query pattern was the **property-key / property-value autocompletes**:

```sql
SELECT DISTINCT property_key, max(created_at)
FROM event_property_values_mv
WHERE project_id = ? GROUP BY property_key
ORDER BY length(property_key) ASC, created_at DESC LIMIT ?
```

It read **1,567,196,999 rows (~57s)** to return only **~6,444 distinct keys**, run ~23×/day. The value-by-key query (`… WHERE property_key=? GROUP BY property_value`) was similar (3.18 GiB).

**Root cause:** the MV is `ORDER BY (project_id, name, property_key, property_value)`. `property_key` sits behind `name`, so the project-wide distinct-key query (no `name` filter) can't use the primary index and full-scans; the value query can't seek on `property_key` either.

## Fix

Add two **aggregating projections** to the MV's storage table:
- `epv_keys` → `(project_id, property_key)` with `max(created_at)`
- `epv_values` → `(project_id, property_key, property_value)` with `max(created_at)`

The query optimizer rewrites the dropdown queries to read the projection — **transparent, no application change**.

`SharedAggregatingMergeTree` requires `deduplicate_merge_projection_mode='rebuild'` before a projection can be added (keeps the projection correct across dedup-merges); the migration sets it.

### Verified on prod
The distinct-`property_key` query dropped from **1.57 B rows / ~57 s** to **20,557 rows / ~8 ms** (~76,000× less data).

### Migration notes
- Idempotent: `ADD PROJECTION IF NOT EXISTS`, and `MATERIALIZE` is **skipped where the projection already has active parts** — so it's a no-op on Newton prod (applied by hand first) and instant on a fresh/empty MV.
- Resolves the MV's storage table for both single-node (`.inner_id.<uuid>`) and clustered (`<mv>_replicated`).
- One-time `MATERIALIZE` rescans the MV (~27 GiB); run with CH scaled up.

## Not included — cohort/profile `profile_id IN (…)` full scans (a separate bucket)

I evaluated rerouting the cohort/per-profile breakdowns to `profile_event_summary_mv` and **rejected it**: that MV (a) excludes anon (`profile_id != device_id`), dropping the alias/anonymous events `cohortMembersInClause` deliberately counts, and (b) was created `populate:false` with only ~30 days backfilled. Measured on a real cohort, MV-routing was **5–7× off** (e.g. `click` 35,694 → 4,995). The correct fix for that bucket (an `events (project_id, profile_id, created_at)` projection, or a fully-backfilled anon-inclusive profile-keyed MV) is heavier and left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)