### PR TITLE
hotfix(migration 16): drop system.projection_parts guard — crashlooping the migration init

### DIFF
--- a/packages/db/code-migrations/16-event-property-values-projections.ts
+++ b/packages/db/code-migrations/16-event-property-values-projections.ts
@@ -62,20 +62,6 @@ async function resolveStorageTable(isClustered: boolean): Promise<string> {
   return rows[0].t;
 }
 
-async function projectionHasParts(
-  storage: string,
-  projection: string,
-): Promise<boolean> {
-  const rows = await jsonRows<{ c: string }>(
-    `SELECT count() AS c FROM system.projection_parts
-     WHERE database = currentDatabase()
-       AND table = '${storage.replace(/'/g, "''")}'
-       AND name = '${projection}'
-       AND active`,
-  );
-  return Number(rows[0]?.c ?? 0) > 0;
-}
-
 export async function up() {
   const isClustered = getIsCluster();
   const storage = await resolveStorageTable(isClustered);
@@ -88,6 +74,16 @@ export async function up() {
       (p) =>
         `ALTER TABLE ${tbl}${onCluster} ADD PROJECTION IF NOT EXISTS ${p.name} (${p.def})`,
     ),
+    // Backfill existing parts. Unconditional MATERIALIZE: the migration user
+    // (openpanel_writer) has ALTER but NOT SELECT on system.projection_parts, so we
+    // can't read it to guard. MATERIALIZE is idempotent — it submits an async mutation
+    // (does not block the migration) that recomputes the same projection data, and it's
+    // instant on a fresh/empty MV. Where the projection is already materialized (e.g. a
+    // hand-applied prod), the env's codeMigration record should mark this applied so it's
+    // skipped instead of needlessly recomputing.
+    ...PROJECTIONS.map(
+      (p) => `ALTER TABLE ${tbl}${onCluster} MATERIALIZE PROJECTION ${p.name}`,
+    ),
   ];
 
   if (process.argv.includes('--dry')) {
@@ -96,18 +92,6 @@ export async function up() {
   }
 
   await runClickhouseMigrationCommands(ddl);
-
-  // Backfill the projections into existing parts. Guarded so we don't re-scan
-  // 1.57B rows where the projection is already materialized.
-  for (const p of PROJECTIONS) {
-    if (await projectionHasParts(storage, p.name)) {
-      console.log(`[16] projection ${p.name} already materialized — skipping`);
-      continue;
-    }
-    await runClickhouseMigrationCommands([
-      `ALTER TABLE ${tbl}${onCluster} MATERIALIZE PROJECTION ${p.name}`,
-    ]);
-  }
 }
 
 export async function down() {


### PR DESCRIPTION
## Urgent — the migration init container is crashlooping on deploy

`openpanel-migration` init logs:
```
✅ Running Migration: 16-event-property-values-projections.ts
   ALTER … MODIFY SETTING deduplicate_merge_projection_mode = 'rebuild'   ✅
   ALTER … ADD PROJECTION IF NOT EXISTS epv_keys …                        ✅
   ALTER … ADD PROJECTION IF NOT EXISTS epv_values …                      ✅
❌ Migration Failed: openpanel_writer: Not enough privileges. To execute this
   query, it's necessary to have the grant SELECT(…) ON system.projection_parts.
```

The `ALTER`s succeed (the migration user `openpanel_writer` has `ALTER`), but the migration's `projectionHasParts()` guard reads **`system.projection_parts`**, which `openpanel_writer` has no `SELECT` grant on → it throws → init `CrashLoopBackOff`. No outage (the previous migration replica still serves), but the rollout is stuck.

## Fix
Remove the `system.projection_parts` dependency and run `MATERIALIZE PROJECTION` **unconditionally**. It's idempotent — submits an async mutation (doesn't block the migration), instant on a fresh/empty MV, and a harmless recompute where already materialized. (`resolveStorageTable` still reads `system.tables`, which the writer *can* read — that's why the `ALTER`s ran.)

## Deploying to envs where the projection was applied by hand (prod)
Prod already has both projections materialized (applied manually + the `ALTER`s here are no-ops). To avoid a redundant async re-materialize of `epv_values` (~6 GiB) on the next deploy, mark this migration applied in the `CodeMigration` table so it's **skipped** on prod — that also stops the current crashloop immediately without waiting for this redeploy. Fresh envs run it normally.

Follow-up to #5 (which introduced migration 16).

🤖 Generated with [Claude Code](https://claude.com/claude-code)