### PR TITLE
perf(ch): device_alias dict cache -> hashed (Bucket 4 — events_resolved ~16x)

### DIFF
--- a/packages/db/code-migrations/18-profile-alias-resolution.admin.sql
+++ b/packages/db/code-migrations/18-profile-alias-resolution.admin.sql
@@ -43,12 +43,19 @@ ORDER BY (project_id, alias)
 TTL created_at + INTERVAL 540 DAY
 SETTINGS index_granularity = 8192;
 
--- 2) Lazy, RAM-bounded cache dictionary: (project_id, cookie) -> uid.
---    COMPLEX_KEY_CACHE: populated on demand, LRU-evicts cold keys, never
---    eager-loads the whole map. SIZE_IN_CELLS bounds RAM (~2 GB worst case).
---    allow_read_expired_keys: serve a stale value + refresh async (no per-row
---    stall). FINAL on the ReplacingMergeTree source yields the latest uid per
---    cookie; the cache-miss key filter pushes into the (project_id, alias) PK.
+-- 2) In-memory hashed dictionary: (project_id, cookie) -> uid.
+--    COMPLEX_KEY_HASHED eager-loads the whole map into a RAM hash table, so every
+--    dictGet is an O(1) in-memory lookup with NO per-key source round-trip.
+--    profile_aliases is tiny (~48K rows / ~1.5 MiB) so this is only a few MB resident.
+--    LIFETIME reloads the whole map every ~hour (picks up new aliases from the
+--    discovery cron). FINAL on the ReplacingMergeTree source yields the latest uid
+--    per cookie at load time.
+--
+--    NOTE: the prior COMPLEX_KEY_CACHE(8388608) layout was a severe perf bug for a
+--    48K-row source — it cache-missed to `profile_aliases FINAL` per lookup
+--    (element_count=0, hit_rate=0), making `events_resolved` ~7x slower than `events`
+--    (every funnel / resolved chart paid it). Measured swap to HASHED: resolution
+--    2151ms -> 132ms (~16x) on a 4M-row scan, identical values (same source data).
 CREATE DICTIONARY openpanel.device_alias
 (
   project_id String,
@@ -57,9 +64,8 @@ CREATE DICTIONARY openpanel.device_alias
 )
 PRIMARY KEY project_id, alias
 SOURCE(CLICKHOUSE(QUERY 'SELECT project_id, alias, profile_id FROM openpanel.profile_aliases FINAL'))
-LAYOUT(COMPLEX_KEY_CACHE(SIZE_IN_CELLS 8388608))
-LIFETIME(MIN 3000 MAX 3600)
-SETTINGS(allow_read_expired_keys = 1);
+LAYOUT(COMPLEX_KEY_HASHED())
+LIFETIME(MIN 3000 MAX 3600);
 
 -- 3) Let the dashboard (reader) resolve through the dictionary.
 GRANT dictGet ON openpanel.device_alias TO openpanel_reader;


### PR DESCRIPTION
## Problem (Bucket 4)
`events_resolved` (the anon→identified resolution view used by funnels + resolved charts) was **~7× slower than `events`** for the same scan. Root cause: the `device_alias` dictionary it relies on was `COMPLEX_KEY_CACHE(SIZE_IN_CELLS 8388608)` — but its source (`profile_aliases`) is only **47,621 rows / 1.5 MiB**. A cache-layout dict over a tiny source cache-misses to `profile_aliases FINAL` on every lookup (`element_count=0`, `hit_rate=0`), so each `dictGet` is effectively a source round-trip.

## Fix
Switch to `COMPLEX_KEY_HASHED()` — eager-load the whole 48K-row map into RAM (a few MB), O(1) lookups, no source round-trips. `LIFETIME` still reloads ~hourly to pick up new aliases.

## Measured (prod, side-by-side test dict, same source)
`uniq(dictGet(...))` over a 4M-row scan: **2151 ms → 132 ms (~16×)**, identical resolution values. Collapses the resolution overhead every Bucket-4 query pays (funnels, `_uc` uniq, resolved charts).

## Applying
The dict is an **admin runbook object** (created as the `default` user on Cloud — a non-default user can't own a CLICKHOUSE-source dict). This PR updates the runbook; to apply to an existing env, run as `default`:
```sql
CREATE OR REPLACE DICTIONARY openpanel.device_alias
( project_id String, alias String, profile_id String )
PRIMARY KEY project_id, alias
SOURCE(CLICKHOUSE(QUERY 'SELECT project_id, alias, profile_id FROM openpanel.profile_aliases FINAL'))
LAYOUT(COMPLEX_KEY_HASHED())
LIFETIME(MIN 3000 MAX 3600);
```
`CREATE OR REPLACE` is atomic; the `events_resolved` view + reader grant are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)