### PR TITLE
fix(ch): drop auto-backfill from migration 19 (apply MODIFY QUERY only)

### DIFF
--- a/packages/db/code-migrations/19-identified-events-in-profile-mvs.ts
+++ b/packages/db/code-migrations/19-identified-events-in-profile-mvs.ts
@@ -30,14 +30,24 @@ import { getIsCluster } from './helpers';
  *
  * The `profiles_is_external` dictionary is created by the `default` user in the
  * companion 19-...admin.sql (Cloud requires `default` for CLICKHOUSE-source
- * dicts) — RUN THAT FIRST.
+ * dicts) — RUN THAT FIRST, or this migration's ALTER fails fast (dict not found)
+ * and crashloops harmlessly with the MVs unchanged.
  *
  * We `ALTER TABLE ... MODIFY QUERY` (not DROP + CREATE) so the existing MV rows
  * stay live and cohorts/retention have no downtime; only the trigger SELECT
- * changes. The historical rows the old filter missed are then added by the
- * delta backfill below: the events where `profile_id = device_id AND identified`
- * — disjoint from what's already in the MV (`profile_id != device_id`), so no
- * double counting.
+ * changes. This makes the fix effective GOING FORWARD — every new identified
+ * event now lands in the MVs.
+ *
+ * HISTORICAL BACKFILL IS DELIBERATELY NOT DONE HERE. The rows the old filter
+ * missed (`profile_id = device_id AND identified`, ~Apr 24 2026 onward — the
+ * #8100 deploy) total ~10^8 events; aggregating them into the MVs is a multi-
+ * hour job and, because these are AggregatingMergeTree, NOT restart-safe (a re-
+ * run sums state again → double counts). Running that inside the migration's
+ * init container — which k8s/Karpenter can evict mid-run, triggering a full
+ * re-run — risks exactly that. It is therefore a separate, supervised, resumable
+ * operation (chunked INSERT ... SELECT with the same column projections + the
+ * `profile_id = device_id AND identified` delta predicate, run once after this
+ * migration applies). See the rollout notes / runbook.
  *
  * NOTE — the sort keys are intentionally left unchanged: these MVs are shared
  * with other access paths and reordering could regress them. A cohort query
@@ -45,16 +55,10 @@ import { getIsCluster } from './helpers';
  * on a sub-second query — acceptable for cohort-save / report-load paths.
  *
  * Flags:
- *   --dry            Write the .sql artifact and print the plan; execute nothing.
- *   --days=N         Delta-backfill window in days (default 90). Older history
- *                    can be filled by re-running with a larger --days.
- *   --batch-hours=N  Hours of data per backfill INSERT (default 1).
- *   --no-backfill    Apply the MODIFY QUERY only; skip the historical backfill.
+ *   --dry   Write the .sql artifact and print the statements; execute nothing.
  */
 
 const DB = 'openpanel';
-const DEFAULT_DAYS = 90;
-const DEFAULT_BATCH_HOURS = 1;
 
 const isClustered = getIsCluster();
 const isDry = process.argv.includes('--dry');
@@ -64,8 +68,6 @@ const eventsTable = isClustered ? 'events_replicated' : 'events';
 
 // The new "identified user" predicate shared by all three MVs.
 const IDENTIFIED = `(profile_id != device_id OR dictGetOrDefault('${DB}.profiles_is_external', 'is_external', (project_id, profile_id), toUInt8(0)) = 1)`;
-// The rows the OLD filter missed (disjoint from profile_id != device_id).
-const DELTA = `profile_id = device_id AND dictGetOrDefault('${DB}.profiles_is_external', 'is_external', (project_id, profile_id), toUInt8(0)) = 1`;
 
 // Column projections kept byte-for-byte identical to the original MV SELECTs
 // (migrations 3, 13, 14) — only the WHERE differs.
@@ -121,48 +123,19 @@ function whereFor(mv: string, base: string): string {
   return base;
 }
 
-function modifyQuerySql(mv: string): string {
+function modifyQuerySql(mv: string, where: string): string {
   // In clustered mode the writer is the *_replicated MV; non-clustered it's the
   // MV object itself. ON CLUSTER fans the DDL to every replica.
   const target = isClustered ? `${mv}_replicated` : mv;
   const onCluster = isClustered ? ` ON CLUSTER '{cluster}'` : '';
-  const select = SELECTS[mv]!.select(whereFor(mv, IDENTIFIED));
+  const select = SELECTS[mv]!.select(whereFor(mv, where));
   return `ALTER TABLE ${DB}.${target}${onCluster} MODIFY QUERY\n${select}`;
 }
 
-function fmt(d: Date): string {
-  return d.toISOString().slice(0, 19).replace('T', ' ');
-}
-
-function getArg(name: string): string | undefined {
-  const prefix = `--${name}=`;
-  return process.argv.find((a) => a.startsWith(prefix))?.slice(prefix.length);
-}
-
-function backfillBatches(mv: string, start: Date, end: Date, batchHours: number) {
-  const target = isClustered ? `${mv}_replicated` : mv;
-  const batches: { from: string; to: string; sql: string }[] = [];
-  let cursor = new Date(start);
-  while (cursor < end) {
-    const next = new Date(cursor);
-    next.setUTCHours(next.getUTCHours() + batchHours);
-    const batchEnd = next > end ? end : next;
-    const where = whereFor(
-      mv,
-      `${DELTA}\n  AND created_at >= toDateTime('${fmt(cursor)}')\n  AND created_at <  toDateTime('${fmt(batchEnd)}')`,
-    );
-    batches.push({
-      from: fmt(cursor),
-      to: fmt(batchEnd),
-      sql: `INSERT INTO ${DB}.${target}\n${SELECTS[mv]!.select(where)}`,
-    });
-    cursor = batchEnd;
-  }
-  return batches;
-}
-
 export async function up() {
-  const modifyQueries = Object.keys(SELECTS).map(modifyQuerySql);
+  const modifyQueries = Object.keys(SELECTS).map((mv) =>
+    modifyQuerySql(mv, IDENTIFIED),
+  );
 
   // Persist the schema-change SQL alongside the migration (same convention as 18).
   fs.writeFileSync(
@@ -173,63 +146,22 @@ export async function up() {
   if (isDry) {
     console.log('🔍 DRY RUN — MODIFY QUERY statements:');
     modifyQueries.forEach((s) => console.log(`\n${s}\n`));
-  } else {
-    console.log('⚡️ Applying MODIFY QUERY to the 3 MVs (no data dropped)…');
-    await runClickhouseMigrationCommands(modifyQueries);
-  }
-
-  if (process.argv.includes('--no-backfill')) {
-    console.log('⏭  --no-backfill: skipping historical delta backfill.');
     return;
   }
 
-  const days = Number.parseInt(getArg('days') ?? String(DEFAULT_DAYS), 10);
-  const batchHours = Number.parseInt(
-    getArg('batch-hours') ?? String(DEFAULT_BATCH_HOURS),
-    10,
-  );
-  const end = new Date();
-  end.setUTCMinutes(0, 0, 0);
-  const start = new Date(end);
-  start.setUTCDate(start.getUTCDate() - days);
-
+  console.log('⚡️ Applying MODIFY QUERY to the 3 MVs (no data dropped)…');
+  await runClickhouseMigrationCommands(modifyQueries);
   console.log(
-    `📦 Delta backfill (profile_id = device_id AND identified): ${fmt(start)} → ${fmt(end)} (${days}d, ${batchHours}h batches)`,
+    '✅ MV filter updated (go-forward). Run the historical backfill separately — see runbook.',
   );
-
-  for (const mv of Object.keys(SELECTS)) {
-    const batches = backfillBatches(mv, start, end, batchHours);
-    if (isDry) {
-      console.log(`\n── ${mv}: ${batches.length} batches. Sample ──\n${batches[0]?.sql}`);
-      continue;
-    }
-    console.log(`\n🚀 ${mv}: ${batches.length} batches`);
-    const startedAt = Date.now();
-    let done = 0;
-    for (const b of batches) {
-      await runClickhouseMigrationCommands([b.sql]);
-      done++;
-      const every = Math.max(1, Math.ceil(batches.length / 10));
-      if (done % every === 0 || done === batches.length) {
-        console.log(
-          `   [${Math.round((done / batches.length) * 100)}%] ${done}/${batches.length}  elapsed=${Math.round((Date.now() - startedAt) / 1000)}s  (…${b.to})`,
-        );
-      }
-    }
-  }
-
-  console.log('✅ MV filter updated + delta backfill complete.');
 }
 
 export async function down() {
   // Revert the trigger SELECTs to the original `profile_id != device_id` filter.
-  // (Existing rows — including backfilled identified ones — are left in place;
-  // they simply stop being added going forward.)
-  const revert = Object.keys(SELECTS).map((mv) => {
-    const target = isClustered ? `${mv}_replicated` : mv;
-    const onCluster = isClustered ? ` ON CLUSTER '{cluster}'` : '';
-    const select = SELECTS[mv]!.select(whereFor(mv, 'profile_id != device_id'));
-    return `ALTER TABLE ${DB}.${target}${onCluster} MODIFY QUERY\n${select}`;
-  });
+  // (Any rows already materialised under the new filter are left in place; they
+  // simply stop being added going forward.)
+  const revert = Object.keys(SELECTS).map((mv) =>
+    modifyQuerySql(mv, 'profile_id != device_id'),
+  );
   await runClickhouseMigrationCommands(revert);
 }


### PR DESCRIPTION
Follow-up to #9.

Migration 19's `up()` previously ran a 90-day delta backfill in the migration **init container** after the `MODIFY QUERY`. Two problems:

- It's **~167.6M events** (Apr 4M + May 125.6M + Jun 38M — verified; the delta is empty before #8100's Apr 24 deploy), i.e. a multi-hour job.
- The 3 MVs are `AggregatingMergeTree`, so the backfill is **not restart-safe**: the migration is only recorded as applied after `up()` *fully* completes, so if the init pod is evicted mid-run (k8s/Karpenter), it re-runs from scratch and **sums the already-inserted state again → double counts**.

This PR makes migration 19 apply the **`MODIFY QUERY` only** — fast, idempotent, safe to run in an init container. The historical backfill becomes a **separate, supervised, resumable** operation run once after the migration applies (chunked `INSERT … SELECT` with the same column projections + the `profile_id = device_id AND identified` delta predicate).

No change to the filter logic or the companion `19-…admin.sql` (dict + grants). The dict still must exist before the `MODIFY QUERY` runs (else the ALTER fails fast and crashloops harmlessly with MVs unchanged — which is exactly what we observed on the first rollout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)