### PR TITLE
fix(ch): correct profiles_is_external dict source (alias-collision loaded all profiles)

### DIFF
--- a/packages/db/code-migrations/19-identified-events-in-profile-mvs.admin.sql
+++ b/packages/db/code-migrations/19-identified-events-in-profile-mvs.admin.sql
@@ -40,7 +40,11 @@ CREATE DICTIONARY openpanel.profiles_is_external
   is_external UInt8
 )
 PRIMARY KEY project_id, id
-SOURCE(CLICKHOUSE(QUERY 'SELECT project_id, id, toUInt8(1) AS is_external FROM openpanel.profiles FINAL WHERE is_external = 1'))
+-- NOTE: the filter MUST be in a subquery. `SELECT toUInt8(1) AS is_external ... WHERE is_external = 1`
+-- makes the output alias (constant 1) shadow the table column in the WHERE, so it filters 1=1 and
+-- loads EVERY profile (anon included) with is_external=1 — silently breaking the dict. The subquery
+-- keeps the WHERE bound to the real column, so only identified profiles load.
+SOURCE(CLICKHOUSE(QUERY 'SELECT project_id, id, toUInt8(1) AS is_external FROM (SELECT project_id, id FROM openpanel.profiles FINAL WHERE is_external = 1)'))
 LAYOUT(COMPLEX_KEY_HASHED())
 LIFETIME(MIN 3000 MAX 3600);
 


### PR DESCRIPTION
Follow-up to #9 / #10.

The `profiles_is_external` dictionary source in `19-…admin.sql` had a name-collision bug:

```sql
SELECT project_id, id, toUInt8(1) AS is_external FROM openpanel.profiles FINAL WHERE is_external = 1
```

The output alias `is_external` (constant `1`) **shadows the table column** in the `WHERE`, so it evaluates `WHERE 1 = 1` and loads **every** profile (anonymous included), each stamped `is_external = 1`. The MV filter `dictGetOrDefault(...) = 1` would then treat **anonymous** events as identified — *worse* than the original bug it's meant to fix.

**Caught on the live rollout:** `element_count` came back ~**7.95M** (all profiles) instead of ~**2.72M** (identified), and a known anon profile (`mp:distinct_id:…`) resolved to `1`.

Fix: filter inside a subquery so the `WHERE` binds to the real column:

```sql
SELECT project_id, id, toUInt8(1) AS is_external
FROM (SELECT project_id, id FROM openpanel.profiles FINAL WHERE is_external = 1)
```

Verified live after the fix: **2,724,071** elements, anon → default `0`, identified → `1`, and a 50k-profile sample shows 0 anon flagged / 100% identified flagged. The live prod dict has already been rebuilt with this corrected source; this PR brings the runbook in line so future environments don't recreate the broken dict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)