### PR TITLE
fix(funnel): non-strict windowFunnel ordering to match Mixpanel

### DIFF
--- a/packages/db/src/services/funnel.service.ts
+++ b/packages/db/src/services/funnel.service.ts
@@ -77,11 +77,17 @@ export class FunnelService {
   }) {
     const funnels = this.getFunnelConditions(eventSeries, projectId);
     const primaryKey = group === 'profile_id' ? 'profile_id' : 'session_id';
+    // Newton fork: match Mixpanel's default (non-strict) funnel ordering — consecutive
+    // steps require created_at >= prev, not strictly >. OP events carry distinct ms
+    // timestamps so this is largely a no-op on real data, but it aligns with MP for any
+    // same-timestamp/burst sequences. Set NEWTON_FUNNEL_STRICT_INCREASE=1 to restore strict.
+    const windowFunnelMode =
+      process.env.NEWTON_FUNNEL_STRICT_INCREASE === '1' ? ", 'strict_increase'" : '';
 
     return clix(this.client, timezone)
       .select([
         primaryKey,
-        `windowFunnel(${funnelWindowMilliseconds}, 'strict_increase')(toUInt64(toUnixTimestamp64Milli(created_at)), ${funnels.join(', ')}) AS level`,
+        `windowFunnel(${funnelWindowMilliseconds}${windowFunnelMode})(toUInt64(toUnixTimestamp64Milli(created_at)), ${funnels.join(', ')}) AS level`,
         ...(group === 'session_id'
           ? ['argMax(profile_id, created_at) AS profile_id']
           : []),


### PR DESCRIPTION
## What
Funnel conversion (`funnel.service.ts`) used `windowFunnel(..., 'strict_increase')`, which requires **strictly increasing** timestamps between consecutive steps. Mixpanel's default funnel counting is **non-strict** (`>=`). This switches OP to default (non-strict) ordering, gated behind `NEWTON_FUNNEL_STRICT_INCREASE=1` (set it to restore the old behaviour).

This is the only `strict_increase` usage; `conversion.service.ts` already uses default `windowFunnel(...)`.

## Why
Cross-tool funnel comparisons (OP vs MP, e.g. the masterclass / website funnels) diverged at steps that involve same-timestamp or burst event sequences — MP counts them, OP's strict mode rejected them. Aligning the mode removes that source of divergence.

## Perf
**None meaningful.** The `windowFunnel` mode only flips one comparison (`>` → `>=`) when advancing the chain — an O(1) per-event check inside the same single-pass-per-group scan + sort. No change to rows scanned, the `GROUP BY`, memory, partitions, or query plan. The only effect is *result* (more same-timestamp sequences can qualify), not compute cost.

## Note
On OP's real data this is largely a **no-op** — events carry distinct millisecond timestamps, so strict ≈ non-strict (verified on the website + masterclass funnels). The bigger anon→identified reconciliation came separately from backfilling `profile_aliases`. This patch closes the remaining mode mismatch with Mixpanel for any same-timestamp cases.

## Rollback
Set `NEWTON_FUNNEL_STRICT_INCREASE=1` (no redeploy of code needed if env is reloadable) to restore strict ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)