### PR TITLE
fix(cohorts): compute membership from resolved, identity-unfiltered summary MVs

### DIFF
--- a/packages/db/code-migrations/20-resolved-cohort-mvs.ts
+++ b/packages/db/code-migrations/20-resolved-cohort-mvs.ts
@@ -1,0 +1,204 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { TABLE_NAMES } from '../src/clickhouse/client';
+import {
+  createMaterializedView,
+  dropTable,
+  getExistingTables,
+  runClickhouseMigrationCommands,
+} from '../src/clickhouse/migration';
+import { getIsCluster } from './helpers';
+
+/**
+ * Event-keyed, identity-unfiltered cohort summary MVs (Newton fork).
+ *
+ * THE BUG -------------------------------------------------------------------
+ * Event-based cohort membership is computed from profile_event_summary_mv /
+ * profile_event_property_summary_mv, which filter at INSERT time to
+ * "identified" rows:
+ *
+ *   (profile_id != device_id) OR profiles_is_external = 1
+ *
+ * Two structural problems (verified on prod, ~15% membership undercount on
+ * `experiment_started` vs the events explorer):
+ *
+ *  1. The MV judges identity ONCE, per event row, at insert. An event fired
+ *     while anonymous is dropped and NEVER re-admitted — a later identify()
+ *     flips the dictionary but old rows are gone. The 30-min cohort refresh
+ *     faithfully re-reads a source that is permanently missing those rows.
+ *  2. The identity signal itself is corrupted: newton-web sends
+ *     device_id == profile_id == uid for logged-in users and never calls
+ *     identify(), so real identified users fail both arms of the filter
+ *     (e.g. uid FND1NU1J3O) and are swept out with the anon traffic.
+ *
+ * Meanwhile the events explorer / funnels read events_resolved (no identity
+ * gate, device_alias folding) — hence "cohort members < users who fired the
+ * event" (Mihir, 2026-07-02).
+ *
+ * THE FIX -------------------------------------------------------------------
+ * New summary tables with NO identity filter; all interpretation moves to
+ * read time, where cohort.service folds raw ids through the device_alias
+ * dictionary (identical semantics to events_resolved). The raw profile_id
+ * key is immutable at insert, so nothing can go stale: a late identify()
+ * heals retroactively at the next 30-min refresh.
+ *
+ * While we're rebuilding anyway, the sort key is reshaped for the ONLY
+ * consumer (cohort.service — it filters project/name/property/date and
+ * groups by profile, never filters by profile):
+ *
+ *   old: (project_id, profile_id, name, property_key, event_date)
+ *   new: (project_id, name, [property_key, property_value,] event_date, profile_id)
+ *
+ * With profile_id second the old key couldn't prune anything — a cohort
+ * criterion scanned the whole project slice (measured: 47.9M rows read for
+ * ~40K matches). The new key prunes to the criterion's own slice: measured
+ * estimate ~50-100x less I/O per cohort compute.
+ *
+ * The old MVs are left in place (cohort_events_mv is untouched — it serves
+ * the cohort events chart). Drop profile_event_summary_mv /
+ * profile_event_property_summary_mv in a follow-up migration once the new
+ * tables are verified.
+ *
+ * BACKFILL ------------------------------------------------------------------
+ * populate: false — the MVs only index events inserted after CREATE. History
+ * must be backfilled with the companion script (NOT auto-run; it is a
+ * supervised, month-partition-aligned, resumable operation):
+ *
+ *   packages/db/code-migrations/backfill-resolved-cohort-mvs.ts
+ *
+ * Until the backfill completes, cohorts with relative timeframes compute
+ * from partial data — run it promptly after deploy.
+ *
+ * Flags:
+ *   --dry   Write the .sql artifact and print the statements; execute nothing.
+ */
+export async function up() {
+  const replicatedVersion = '1';
+  const existingTables = await getExistingTables();
+  const isClustered = getIsCluster();
+
+  const sqls: string[] = [];
+
+  if (
+    !existingTables.includes(
+      `${TABLE_NAMES.event_profile_summary_mv}_distributed`,
+    ) &&
+    !existingTables.includes(TABLE_NAMES.event_profile_summary_mv)
+  ) {
+    sqls.push(
+      ...createMaterializedView({
+        name: TABLE_NAMES.event_profile_summary_mv,
+        tableName: 'events',
+        engine: 'AggregatingMergeTree()',
+        orderBy: ['project_id', 'name', 'event_date', 'profile_id'],
+        partitionBy: 'toYYYYMM(event_date)',
+        query: `SELECT
+          project_id,
+          profile_id,
+          name,
+          toStartOfDay(created_at) AS event_date,
+          countState() AS event_count,
+          minState(created_at) AS first_event_time,
+          maxState(created_at) AS last_event_time,
+          sumState(duration) AS total_duration
+        FROM {events}
+        GROUP BY project_id, profile_id, name, event_date`,
+        distributionHash: 'cityHash64(project_id, profile_id)',
+        replicatedVersion,
+        isClustered,
+        populate: false,
+      }),
+    );
+  }
+
+  if (
+    !existingTables.includes(
+      `${TABLE_NAMES.event_property_profile_summary_mv}_distributed`,
+    ) &&
+    !existingTables.includes(TABLE_NAMES.event_property_profile_summary_mv)
+  ) {
+    sqls.push(
+      ...createMaterializedView({
+        name: TABLE_NAMES.event_property_profile_summary_mv,
+        tableName: 'events',
+        engine: 'AggregatingMergeTree()',
+        orderBy: [
+          'project_id',
+          'name',
+          'property_key',
+          'property_value',
+          'event_date',
+          'profile_id',
+        ],
+        partitionBy: 'toYYYYMM(event_date)',
+        query: `SELECT
+          project_id,
+          profile_id,
+          name,
+          property_key,
+          property_value,
+          toStartOfDay(created_at) AS event_date,
+          countState() AS event_count,
+          minState(created_at) AS first_event_time,
+          maxState(created_at) AS last_event_time
+        FROM {events}
+        ARRAY JOIN mapKeys(properties) AS property_key, mapValues(properties) AS property_value
+        WHERE property_key != ''
+          AND property_value != ''
+        GROUP BY project_id, profile_id, name, property_key, property_value, event_date`,
+        distributionHash: 'cityHash64(project_id, profile_id)',
+        replicatedVersion,
+        isClustered,
+        populate: false,
+      }),
+    );
+  }
+
+  fs.writeFileSync(
+    path.join(import.meta.filename.replace('.ts', '.sql')),
+    sqls
+      .map((sql) =>
+        sql
+          .trim()
+          .replace(/;$/, '')
+          .replace(/\n{2,}/g, '\n')
+          .concat(';'),
+      )
+      .join('\n\n---\n\n'),
+  );
+
+  if (process.argv.includes('--dry')) {
+    console.log('🔍 DRY RUN — CREATE statements:');
+    sqls.forEach((s) => console.log(`\n${s}\n`));
+    return;
+  }
+
+  await runClickhouseMigrationCommands(sqls);
+}
+
+export async function down() {
+  const isClustered = getIsCluster();
+
+  const sqls = [
+    dropTable(
+      `${TABLE_NAMES.event_profile_summary_mv}_distributed`,
+      isClustered,
+    ),
+    dropTable(
+      `${TABLE_NAMES.event_profile_summary_mv}_replicated`,
+      isClustered,
+    ),
+    dropTable(TABLE_NAMES.event_profile_summary_mv, isClustered),
+    dropTable(
+      `${TABLE_NAMES.event_property_profile_summary_mv}_distributed`,
+      isClustered,
+    ),
+    dropTable(
+      `${TABLE_NAMES.event_property_profile_summary_mv}_replicated`,
+      isClustered,
+    ),
+    dropTable(TABLE_NAMES.event_property_profile_summary_mv, isClustered),
+  ];
+
+  await runClickhouseMigrationCommands(sqls);
+}

--- a/packages/db/code-migrations/backfill-resolved-cohort-mvs.ts
+++ b/packages/db/code-migrations/backfill-resolved-cohort-mvs.ts
@@ -1,0 +1,288 @@
+import { TABLE_NAMES } from '../src/clickhouse/client';
+import {
+  chMigrationClient,
+  runClickhouseMigrationCommands,
+} from '../src/clickhouse/migration';
+import { getIsCluster } from './helpers';
+
+/**
+ * Backfill the resolved cohort summary MVs (migration 20) with full history.
+ *
+ *   - event_profile_summary_mv
+ *   - event_property_profile_summary_mv
+ *
+ * Both were created with `populate: false`, so they only index events inserted
+ * AFTER their CREATE ran. This feeds them everything before that.
+ *
+ * DELIBERATELY NOT A NUMBERED MIGRATION: migrate.ts only auto-runs files whose
+ * name starts with a number, so this never executes inside the init container
+ * (where an eviction mid-run would force a full re-run). Run it supervised:
+ *
+ *   pnpm tsx packages/db/code-migrations/backfill-resolved-cohort-mvs.ts [flags]
+ *
+ * RESTART SAFETY -------------------------------------------------------------
+ * AggregatingMergeTree is NOT idempotent under re-insert (countState rows merge
+ * additively → re-running a range double-counts). The safe unit of retry is the
+ * MONTH, because batches are aligned to the tables' toYYYYMM partitions:
+ * if a month fails or is interrupted midway, re-run JUST that month with
+ * --replace, which drops the month's partition on the target first.
+ *
+ * IMPORTANT: pass --until=<CREATE time of the MVs, UTC 'YYYY-MM-DD hh:mm:ss'>.
+ * Events inserted after CREATE are already indexed by the live MV trigger;
+ * backfilling past that point double-counts the overlap. Find it with:
+ *   SELECT metadata_modification_time FROM system.tables WHERE name = 'event_profile_summary_mv'
+ *
+ * Flags:
+ *   --dry              Print per-month plan + first batch SQL; execute nothing.
+ *   --from=YYYYMM      First month to backfill (default: month of min(created_at)).
+ *   --to=YYYYMM        Last month to backfill (default: current month).
+ *   --until=DATETIME   Upper bound on created_at (REQUIRED unless --dry; see above).
+ *   --batch-days=N     Days of data per INSERT within a month (default 2).
+ *   --replace          DROP PARTITION on the target before each month (retry mode).
+ *   --only=summary|property   Backfill just one of the two tables.
+ */
+
+const DEFAULT_BATCH_DAYS = 2;
+
+// Spill the per-batch GROUP BY to disk instead of OOMing on the ARRAY JOIN
+// fan-out; harmless for the narrow summary inserts.
+const INSERT_SETTINGS =
+  'SETTINGS max_bytes_before_external_group_by = 4294967296';
+
+type Batch = { label: string; sql: string };
+
+function getArg(name: string): string | undefined {
+  const prefix = `--${name}=`;
+  const arg = process.argv.find((a) => a.startsWith(prefix));
+  return arg?.slice(prefix.length);
+}
+
+function resolveTargetTable(baseName: string, isClustered: boolean): string {
+  return isClustered ? `${baseName}_replicated` : baseName;
+}
+
+function monthStart(yyyymm: number): string {
+  const y = Math.floor(yyyymm / 100);
+  const m = yyyymm % 100;
+  return `${y}-${String(m).padStart(2, '0')}-01 00:00:00`;
+}
+
+function nextMonth(yyyymm: number): number {
+  const y = Math.floor(yyyymm / 100);
+  const m = yyyymm % 100;
+  return m === 12 ? (y + 1) * 100 + 1 : yyyymm + 1;
+}
+
+function summarySelect(startStr: string, endStr: string): string {
+  return `SELECT
+  project_id,
+  profile_id,
+  name,
+  toStartOfDay(created_at) AS event_date,
+  countState() AS event_count,
+  minState(created_at) AS first_event_time,
+  maxState(created_at) AS last_event_time,
+  sumState(duration) AS total_duration
+FROM events
+WHERE created_at >= toDateTime('${startStr}')
+  AND created_at <  toDateTime('${endStr}')
+GROUP BY project_id, profile_id, name, event_date`;
+}
+
+function propertySelect(startStr: string, endStr: string): string {
+  return `SELECT
+  project_id,
+  profile_id,
+  name,
+  property_key,
+  property_value,
+  toStartOfDay(created_at) AS event_date,
+  countState() AS event_count,
+  minState(created_at) AS first_event_time,
+  maxState(created_at) AS last_event_time
+FROM events
+ARRAY JOIN mapKeys(properties) AS property_key, mapValues(properties) AS property_value
+WHERE created_at >= toDateTime('${startStr}')
+  AND created_at <  toDateTime('${endStr}')
+  AND property_key != ''
+  AND property_value != ''
+GROUP BY project_id, profile_id, name, property_key, property_value, event_date`;
+}
+
+function generateMonthBatches(
+  month: number,
+  until: string,
+  batchDays: number,
+  targetTable: string,
+  select: (start: string, end: string) => string,
+): Batch[] {
+  const batches: Batch[] = [];
+  const start = new Date(`${monthStart(month).replace(' ', 'T')}Z`);
+  const monthEnd = new Date(`${monthStart(nextMonth(month)).replace(' ', 'T')}Z`);
+  const untilDate = new Date(`${until.replace(' ', 'T')}Z`);
+  const end = monthEnd < untilDate ? monthEnd : untilDate;
+
+  let cursor = new Date(start);
+  while (cursor < end) {
+    const next = new Date(cursor);
+    next.setUTCDate(next.getUTCDate() + batchDays);
+    const batchEnd = next > end ? end : next;
+
+    const startStr = cursor.toISOString().slice(0, 19).replace('T', ' ');
+    const endStr = batchEnd.toISOString().slice(0, 19).replace('T', ' ');
+
+    batches.push({
+      label: `${startStr} → ${endStr}`,
+      sql: `INSERT INTO ${targetTable}\n${select(startStr, endStr)}\n${INSERT_SETTINGS}`,
+    });
+    cursor = batchEnd;
+  }
+
+  return batches;
+}
+
+async function getMinMonth(): Promise<number> {
+  const result = await chMigrationClient.query({
+    query: 'SELECT toYYYYMM(min(created_at)) AS m FROM events',
+    format: 'JSONEachRow',
+  });
+  const rows = await result.json<{ m: string }>();
+  return Number(rows[0]?.m ?? 0);
+}
+
+export async function up() {
+  const isClustered = getIsCluster();
+  const isDryRun = process.argv.includes('--dry');
+  const replaceMode = process.argv.includes('--replace');
+  const only = getArg('only');
+  const batchDays = Number.parseInt(
+    getArg('batch-days') ?? String(DEFAULT_BATCH_DAYS),
+    10,
+  );
+
+  const now = new Date();
+  const currentMonth = now.getUTCFullYear() * 100 + (now.getUTCMonth() + 1);
+  const fromMonth = Number.parseInt(
+    getArg('from') ?? String(await getMinMonth()),
+    10,
+  );
+  const toMonth = Number.parseInt(getArg('to') ?? String(currentMonth), 10);
+  const until = getArg('until');
+
+  if (!until && !isDryRun) {
+    console.error(
+      '❌ --until=<MV CREATE time, UTC> is required (see header comment) — without it the window indexed by the live MV trigger double-counts.',
+    );
+    process.exit(1);
+  }
+  const untilStr =
+    until ?? now.toISOString().slice(0, 19).replace('T', ' ');
+
+  const targets: Array<{
+    label: string;
+    table: string;
+    select: (s: string, e: string) => string;
+  }> = [];
+  if (only !== 'property') {
+    targets.push({
+      label: 'event_profile_summary_mv',
+      table: resolveTargetTable(TABLE_NAMES.event_profile_summary_mv, isClustered),
+      select: summarySelect,
+    });
+  }
+  if (only !== 'summary') {
+    targets.push({
+      label: 'event_property_profile_summary_mv',
+      table: resolveTargetTable(
+        TABLE_NAMES.event_property_profile_summary_mv,
+        isClustered,
+      ),
+      select: propertySelect,
+    });
+  }
+
+  const months: number[] = [];
+  for (let m = fromMonth; m <= toMonth; m = nextMonth(m)) {
+    months.push(m);
+  }
+
+  console.log('');
+  console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
+  console.log('📦 Resolved cohort MV backfill');
+  console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
+  console.log(`   Months:      ${fromMonth} → ${toMonth} (${months.length})`);
+  console.log(`   Until:       ${untilStr}`);
+  console.log(`   Batch size:  ${batchDays} day${batchDays === 1 ? '' : 's'}`);
+  console.log(`   Replace:     ${replaceMode}`);
+  console.log(`   Targets:     ${targets.map((t) => t.label).join(', ')}`);
+  console.log(`   Mode:        ${isDryRun ? 'DRY RUN' : 'EXECUTE'}`);
+  console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
+
+  if (isDryRun) {
+    for (const target of targets) {
+      const sample = generateMonthBatches(
+        months[0]!,
+        untilStr,
+        batchDays,
+        target.table,
+        target.select,
+      );
+      console.log('');
+      console.log(`── Sample batch (${target.label}, ${sample.length} batches for ${months[0]}) ──`);
+      console.log(sample[0]?.sql);
+    }
+    return;
+  }
+
+  const startedAt = Date.now();
+  for (const target of targets) {
+    console.log('');
+    console.log(`🚀 ${target.label}`);
+    for (const month of months) {
+      const batches = generateMonthBatches(
+        month,
+        untilStr,
+        batchDays,
+        target.table,
+        target.select,
+      );
+      if (batches.length === 0) {
+        continue;
+      }
+
+      if (replaceMode) {
+        await runClickhouseMigrationCommands([
+          `ALTER TABLE ${target.table} DROP PARTITION '${month}'`,
+        ]);
+      }
+
+      const t0 = Date.now();
+      for (const batch of batches) {
+        await runClickhouseMigrationCommands([batch.sql]);
+      }
+      const monthSec = Math.round((Date.now() - t0) / 1000);
+      const elapsedSec = Math.round((Date.now() - startedAt) / 1000);
+      console.log(
+        `   ✅ ${month} done in ${monthSec}s (${batches.length} batches, elapsed=${elapsedSec}s)`,
+      );
+    }
+  }
+
+  console.log('');
+  console.log('✅ Backfill complete.');
+}
+
+export async function down() {
+  console.log('⚠️  No down migration — re-run a month with --replace to redo it,');
+  console.log('   or DROP + recreate the tables via migration 20 down/up.');
+}
+
+// Allow direct execution: pnpm tsx packages/db/code-migrations/backfill-resolved-cohort-mvs.ts
+if (import.meta.url === `file://${process.argv[1]}`) {
+  up()
+    .then(() => process.exit(0))
+    .catch((err) => {
+      console.error(err);
+      process.exit(1);
+    });
+}

--- a/packages/db/src/clickhouse/client.ts
+++ b/packages/db/src/clickhouse/client.ts
@@ -73,6 +73,13 @@ export const TABLE_NAMES = {
   cohort_metadata: 'cohort_metadata',
   profile_event_summary_mv: 'profile_event_summary_mv',
   profile_event_property_summary_mv: 'profile_event_property_summary_mv',
+  // Newton fork (migration 20): event-keyed, identity-unfiltered replacements
+  // for the two profile_event_* MVs above. Keyed (project, name, [property],
+  // date, profile) so cohort criteria prune to their own slice, and populated
+  // WITHOUT the identified-only gate — identity is resolved at read time via
+  // the device_alias dictionary instead (see cohort.service).
+  event_profile_summary_mv: 'event_profile_summary_mv',
+  event_property_profile_summary_mv: 'event_property_profile_summary_mv',
 };
 
 /**

--- a/packages/db/src/services/cohort.service.ts
+++ b/packages/db/src/services/cohort.service.ts
@@ -17,6 +17,20 @@ import { getProfiles, type IServiceProfile } from './profile.service';
 
 export const COHORT_MATERIALIZE_LIMIT = 10000;
 
+// Newton fork: cohort criteria are evaluated on the RESOLVED identity — the
+// raw profile_id folded through the device_alias dictionary, exactly like the
+// events_resolved view. This replaces the old identified-only MV gate
+// (`profile_id != device_id OR is_external = 1`), which undercounted
+// membership two ways: events fired while anonymous were dropped at insert
+// and never re-admitted after identify(), and newton-web sends
+// device_id == profile_id == uid so real identified users failed both arms.
+// Resolution at read is self-healing: a late-discovered alias folds a
+// member's pre-login events in at the next scheduled recompute. Membership is
+// stored as resolved ids, which is what its consumers already expect
+// (cohortMembersInClause re-expands members to their aliases; the all-cohorts
+// chart joins against events_resolved profile_ids).
+const RESOLVED_PROFILE_ID = `dictGetOrDefault('openpanel.device_alias', 'profile_id', (project_id, profile_id), profile_id)`;
+
 function buildTimeConstraint(timeframe: Timeframe): string {
   if (timeframe.type === 'relative') {
     const match = timeframe.value.match(/^(\d+)d$/);
@@ -109,8 +123,8 @@ export function buildEventCriteriaQuery(
     if (frequency) {
       const frequencyOp = getFrequencyOperator(frequency);
       return `
-        SELECT profile_id
-        FROM ${TABLE_NAMES.profile_event_property_summary_mv}
+        SELECT ${RESOLVED_PROFILE_ID} AS profile_id
+        FROM ${TABLE_NAMES.event_property_profile_summary_mv}
         WHERE project_id = ${sqlstring.escape(projectId)}
           AND name = ${sqlstring.escape(name)}
           AND ${timeConstraint.replace('created_at', 'event_date')}
@@ -121,8 +135,8 @@ export function buildEventCriteriaQuery(
     }
 
     return `
-      SELECT DISTINCT profile_id
-      FROM ${TABLE_NAMES.profile_event_property_summary_mv}
+      SELECT DISTINCT ${RESOLVED_PROFILE_ID} AS profile_id
+      FROM ${TABLE_NAMES.event_property_profile_summary_mv}
       WHERE project_id = ${sqlstring.escape(projectId)}
         AND name = ${sqlstring.escape(name)}
         AND ${timeConstraint.replace('created_at', 'event_date')}
@@ -133,8 +147,8 @@ export function buildEventCriteriaQuery(
   if (frequency) {
     const frequencyOp = getFrequencyOperator(frequency);
     return `
-      SELECT profile_id
-      FROM ${TABLE_NAMES.profile_event_summary_mv}
+      SELECT ${RESOLVED_PROFILE_ID} AS profile_id
+      FROM ${TABLE_NAMES.event_profile_summary_mv}
       WHERE project_id = ${sqlstring.escape(projectId)}
         AND name = ${sqlstring.escape(name)}
         AND ${timeConstraint.replace('created_at', 'event_date')}
@@ -144,8 +158,8 @@ export function buildEventCriteriaQuery(
   }
 
   return `
-    SELECT DISTINCT profile_id
-    FROM ${TABLE_NAMES.profile_event_summary_mv}
+    SELECT DISTINCT ${RESOLVED_PROFILE_ID} AS profile_id
+    FROM ${TABLE_NAMES.event_profile_summary_mv}
     WHERE project_id = ${sqlstring.escape(projectId)}
       AND name = ${sqlstring.escape(name)}
       AND ${timeConstraint.replace('created_at', 'event_date')}

--- a/packages/db/src/services/delete.service.ts
+++ b/packages/db/src/services/delete.service.ts
@@ -51,6 +51,8 @@ export async function deleteFromClickhouse(projectIds: string[]) {
     TABLE_NAMES.cohort_metadata,
     TABLE_NAMES.profile_event_summary_mv,
     TABLE_NAMES.profile_event_property_summary_mv,
+    TABLE_NAMES.event_profile_summary_mv,
+    TABLE_NAMES.event_property_profile_summary_mv,
   ];
 
   for (const table of tables) {


### PR DESCRIPTION
## Problem

Event-based cohort membership undercounts vs the events explorer ("we created this cohort just now, but the members seem to be less than the actual number of users for whom the event was triggered" — reported 2026-07-02). Measured on `experiment_started` (30d): explorer/`events_resolved` = **84,263** distinct users, cohort source MVs = **~75,107**; **12,448** users the explorer shows are invisible to the cohort (**10,422** of them identified 10-char uids). ~15% undercount.

## Root cause

Cohort compute reads `profile_event_summary_mv` / `profile_event_property_summary_mv`, which filter at **insert time** to `(profile_id != device_id) OR is_external = 1`. Two structural failures:

1. **No backfill, ever.** The MV judges each event row once, at insert. An event fired while anonymous is dropped permanently — a later `identify()` flips the dictionary but old rows are never revisited. The 30-min cohort refresh faithfully re-reads a source that is permanently missing those rows.
2. **The identity signal is corrupted upstream.** newton-web sends `device_id == profile_id == uid` for logged-in users and never calls `identify()`, so real identified users fail *both* filter arms (verified: uid `FND1NU1J3O` — all its web events have `profile_id == device_id`, `is_external=0`; web `experiment_started` rows are ~62% pid==did over 7d).

Meanwhile funnels / charts / the events explorer read `events_resolved` (no identity gate + `device_alias` folding) — hence the mismatch. Blast radius of the bad filter is cohorts only (these two MVs' sole runtime reader is `cohort.service`; `cohort_events_mv` shares the filter but is out of scope here).

## Fix

**Migration 20** creates two replacement MVs with **no identity filter** — all interpretation moves to read time:

- `event_profile_summary_mv` — `ORDER BY (project_id, name, event_date, profile_id)`
- `event_property_profile_summary_mv` — `ORDER BY (project_id, name, property_key, property_value, event_date, profile_id)`

**`cohort.service`** now folds raw ids through the `device_alias` dictionary at read (`dictGetOrDefault(...)`), i.e. the exact `events_resolved` semantics — membership matches the explorer by construction, and a late-discovered alias heals **retroactively** at the next 30-min recompute. Stored membership is resolved uids, which is what existing consumers already expect (`cohortMembersInClause` re-expands members to aliases; the all-cohorts chart joins against `events_resolved` ids).

The sort key is reshaped for the only consumer (cohort criteria filter project/name/property/date and *group* by profile — they never filter by profile). The old `profile_id`-second key couldn't prune anything: a criterion scanned the whole project slice (measured 47.9M rows read for ~40K matches). The new key prunes to the criterion's own slice — estimated **~50-100× less I/O** per compute, and the interactive preview count drops to sub-second.

Validated read-only against prod CH: the resolve-at-read query shape (alias GROUP BY + `HAVING countMerge`) executes and returns resolved uids; the DDL parses (`EXPLAIN AST`).

## Deploy / backfill runbook

1. Migration 20 auto-runs (creates empty tables + live triggers; `populate: false`).
2. **Run the backfill promptly** — until it completes, cohorts compute from partial data:
   ```
   pnpm tsx packages/db/code-migrations/backfill-resolved-cohort-mvs.ts --dry
   pnpm tsx packages/db/code-migrations/backfill-resolved-cohort-mvs.ts --until='<MV CREATE time, UTC>'
   ```
   `--until` = the new MVs' CREATE time (`SELECT metadata_modification_time FROM system.tables WHERE name = 'event_profile_summary_mv'`) — events after that are already indexed by the live trigger; going past it double-counts the overlap. The script is deliberately **not numbered** so `migrate.ts` never runs it in the init container. Batches are month-partition aligned: if a month fails midway, re-run **that month** with `--from=YYYYMM --to=YYYYMM --replace` (drops the partition first). AggregatingMergeTree re-inserts double-count — always `--replace` on retry.
3. Verify (membership vs explorer parity), e.g.:
   ```sql
   SELECT uniqExact(profile_id) FROM events_resolved
   WHERE project_id='platform' AND name='experiment_started' AND created_at >= now() - INTERVAL 30 DAY
   -- ≈ cohort preview count for the same criterion
   ```
4. Follow-up (separate PR, after verification): drop `profile_event_summary_mv` / `profile_event_property_summary_mv` — until then inserts pay both triggers.

## Notes

- Anonymous-only profiles (never identified, no alias) now count as members under their device id — same semantics as the explorer/funnels. That's the intended parity; if a future cohort use-case needs identified-only (e.g. targeting), gate on a reliable signal like `profiles.email != ''`, not `is_external`.
- MV storage: unfiltered agg-tuples measured at **2.35×** the identified-only set (7d sample) → property table ~985M → ~2.3B rows, order tens of GB compressed.
- Ingest: until the old MVs are dropped, the property ARRAY-JOIN trigger runs twice per insert.
- Multi-property criteria keep the existing OR semantics (pre-existing quirk, deliberately out of scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)