### PR TITLE
perf(charts): single-pass total_count — halves every chart query's scan

### DIFF
--- a/packages/db/src/services/chart-sql.test.ts
+++ b/packages/db/src/services/chart-sql.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { IChartEvent } from '@openpanel/validation';
+
+const baseEvent: IChartEvent = {
+  id: '1',
+  name: 'sign_up',
+  displayName: 'sign_up',
+  segment: 'event',
+  filters: [],
+};
+
+async function buildChartSql(overrides: Record<string, unknown> = {}) {
+  const { getChartSql } = await import('./chart.service');
+  return getChartSql({
+    event: baseEvent,
+    breakdowns: [],
+    interval: 'day',
+    startDate: '2026-06-01 00:00:00',
+    endDate: '2026-06-02 00:00:00',
+    projectId: 'p1',
+    timezone: 'UTC',
+    ...overrides,
+  } as unknown as Parameters<typeof getChartSql>[0]);
+}
+
+// total_count (unique visitors over the whole range) used to be computed by a
+// `_uc` CTE that re-ran the entire WHERE in a second full scan. It is now a
+// uniqState aggregated in the same pass and merged with a window aggregate in
+// an outer select, so every chart reads the events table exactly once.
+describe('chart sql single-pass total_count', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubEnv('NEWTON_RESOLVE_PROFILE', '1');
+  });
+
+  it('scans events exactly once and merges uniq states globally (no breakdown)', async () => {
+    const sql = await buildChartSql();
+    expect(sql).not.toContain('_uc AS (');
+    expect(sql).toContain('uniqState(profile_id) as _uc_state');
+    expect(sql).toContain('uniqMerge(_uc_state) OVER () as total_count');
+    expect(sql).toContain('* EXCEPT (_uc_state)');
+    // exactly one scan of the events source
+    expect(sql.match(/FROM events_resolved e/g)).toHaveLength(1);
+    expect(sql).not.toMatch(/FROM events e/);
+  });
+
+  it('partitions the merged uniq states by breakdown labels', async () => {
+    const sql = await buildChartSql({
+      breakdowns: [{ id: 'b1', name: 'properties.courseStructureSlug' }],
+    });
+    expect(sql).not.toContain('_uc AS (');
+    expect(sql).not.toContain('LEFT ANY JOIN _uc');
+    expect(sql).toContain(
+      'uniqMerge(_uc_state) OVER (PARTITION BY label_1) as total_count',
+    );
+    expect(sql.match(/FROM events_resolved e/g)).toHaveLength(1);
+  });
+
+  it('keeps ORDER BY and WITH FILL outside the aggregation subquery', async () => {
+    const sql = await buildChartSql();
+    // GROUP BY belongs to the inner scan; ORDER BY/FILL follow its closing paren
+    expect(sql).toMatch(/GROUP BY[^)]*\)\s*ORDER BY date ASC/);
+    expect(sql).toContain('WITH FILL');
+  });
+
+  it('reads raw events for profile-filtered charts (index-safe path)', async () => {
+    const sql = await buildChartSql({
+      event: {
+        ...baseEvent,
+        filters: [
+          {
+            id: 'f1',
+            name: 'profile_id',
+            operator: 'is',
+            value: ['abc'],
+          },
+        ],
+      },
+    });
+    // profile-filtered charts must stay on the raw table for the bloom index
+    expect(sql.match(/FROM events e/g)).toHaveLength(1);
+    expect(sql).not.toContain('FROM events_resolved');
+  });
+});

--- a/packages/db/src/services/chart.service.ts
+++ b/packages/db/src/services/chart.service.ts
@@ -416,15 +416,11 @@ export async function getChartSql({
     sb.joins.groups_table = 'LEFT ANY JOIN _g ON _g.id = _group_id';
   }
 
-  // Build WHERE clause without the bar filter (for use in subqueries and CTEs)
-  // Define this early so we can use it in CTE definitions
-  const getWhereWithoutBar = () => {
-    const whereWithoutBar = { ...sb.where };
-    delete whereWithoutBar.bar;
-    return Object.keys(whereWithoutBar).length
-      ? `WHERE ${join(whereWithoutBar, ' AND ')}`
-      : '';
-  };
+  // The main scan must read the same table the `total_count` unique-visitor
+  // aggregate reads (previously only the `_uc` CTE used chartEventsTable while
+  // the main scan read raw events, so per-date uniques and totals disagreed on
+  // resolved anonymous profiles).
+  sb.from = `${chartEventsTable} e`;
 
   // Collect all profile fields used in filters and breakdowns
   // Extract top-level field names (e.g., 'properties' from 'profile.properties.os')
@@ -620,85 +616,23 @@ export async function getChartSql({
     return sql;
   }
 
-  // Note: The profile CTE (if it exists) is available in subqueries, so we can reference it directly.
-  // Cohort CTEs cannot be referenced from nested CTEs in ClickHouse, so we inline them.
-  const subqueryGroupJoins = needsGroupArrayJoin
-    ? 'ARRAY JOIN groups AS _group_id LEFT ANY JOIN _g ON _g.id = _group_id '
-    : '';
-  const inlineCohortJoinsSql = cohortIds
-    .map((id) => buildInlineCohortJoin(id, projectId, 'e'))
-    .join(' ');
-  // Inline all-cohorts join for use in _uc CTE (can't reference CTEs from nested CTEs)
-  const inlineAllCohortsJoin = hasAllCohortsBreakdown
-    ? `INNER JOIN (${buildAllCohortsMembershipQuery(projectId)}) AS _all_cohorts ON _all_cohorts.profile_id = e.profile_id `
-    : '';
+  // Newton fork: single-pass total_count. Upstream computed total_count with a
+  // second full scan of the same WHERE (a `_uc` CTE, LEFT ANY JOINed back per
+  // breakdown label / injected as a scalar subquery), doubling every chart's
+  // read cost. Instead, aggregate uniqState(profile_id) alongside the series in
+  // the same pass and merge the per-group states in an outer select with a
+  // window aggregate (PARTITION BY the breakdown labels; empty partition =
+  // global total). uniq states merge losslessly, so the result matches the
+  // two-scan form exactly.
+  sb.select.uc_state = 'uniqState(profile_id) as _uc_state';
 
-  if (breakdowns.length > 0) {
-    // Pre-compute unique counts per breakdown group in a CTE, then JOIN it.
-    // We can't use a correlated subquery because:
-    // 1. ClickHouse expands label_X aliases to their underlying expressions,
-    //    which resolve in the subquery's scope, making the condition a tautology.
-    // 2. Correlated subqueries aren't supported on distributed/remote tables.
-    const ucSelectParts: string[] = breakdowns.map((breakdown, index) => {
-      if (isAllCohortsBreakdown(breakdown.name)) {
-        return `${buildAllCohortsLabelExpr(allCohorts)} as _uc_label_${index + 1}`;
-      }
-      const bId = extractCohortId(breakdown.name);
-      const bName = bId ? cohortMetadata.get(bId)?.name : undefined;
-      const propertyKey = getSelectPropertyKey(
-        breakdown.name,
-        projectId,
-        bId ?? undefined,
-        bName,
-      );
-      return `${propertyKey} as _uc_label_${index + 1}`;
-    });
-    ucSelectParts.push('uniq(profile_id) as total_count');
-
-    const ucGroupByParts = breakdowns.map(
-      (_, index) => `_uc_label_${index + 1}`
-    );
-
-    const ucWhere = getWhereWithoutBar();
-
-    addCte(
-      '_uc',
-      `SELECT ${ucSelectParts.join(', ')} FROM ${chartEventsTable} e ${subqueryGroupJoins}${profilesJoinRef ? `${profilesJoinRef} ` : ''}${inlineCohortJoinsSql ? `${inlineCohortJoinsSql} ` : ''}${inlineAllCohortsJoin}${ucWhere} GROUP BY ${ucGroupByParts.join(', ')}`
-    );
-
-    const ucJoinConditions = breakdowns
-      .map((b, index) => {
-        if (isAllCohortsBreakdown(b.name)) {
-          return `_uc._uc_label_${index + 1} = ${buildAllCohortsLabelExpr(allCohorts)}`;
-        }
-        const bId = extractCohortId(b.name);
-        const bName = bId ? cohortMetadata.get(bId)?.name : undefined;
-        const propertyKey = getSelectPropertyKey(
-          b.name,
-          projectId,
-          bId ?? undefined,
-          bName,
-        );
-        return `_uc._uc_label_${index + 1} = ${propertyKey}`;
-      })
-      .join(' AND ');
-
-    sb.joins.unique_counts = `LEFT ANY JOIN _uc ON ${ucJoinConditions}`;
-    sb.select.total_unique_count = 'any(_uc.total_count) as total_count';
-  } else {
-    const ucWhere = getWhereWithoutBar();
-
-    addCte(
-      '_uc',
-      `SELECT uniq(profile_id) as total_count FROM ${chartEventsTable} e ${subqueryGroupJoins}${profilesJoinRef ? `${profilesJoinRef} ` : ''}${inlineCohortJoinsSql ? `${inlineCohortJoinsSql} ` : ''}${ucWhere}`
-    );
-
-    sb.select.total_unique_count =
-      '(SELECT total_count FROM _uc) as total_count';
-  }
+  const totalCountPartition = breakdowns
+    .map((_, index) => `label_${index + 1}`)
+    .join(', ');
+  const totalCountSelect = `uniqMerge(_uc_state) OVER (${totalCountPartition ? `PARTITION BY ${totalCountPartition}` : ''}) as total_count`;
 
   const sql = rewriteProfilePropertyRefs(
-    `${getWith()}${getSelect()} ${getFrom()} ${getJoins()} ${getWhere()} ${getGroupBy()} ${getOrderBy()} ${getFill()}`,
+    `${getWith()}SELECT * EXCEPT (_uc_state), ${totalCountSelect} FROM (${getSelect()} ${getFrom()} ${getJoins()} ${getWhere()} ${getGroupBy()}) ${getOrderBy()} ${getFill()}`,
     collectProfilePropertyKeys([...event.filters, ...breakdowns]).keys,
   );
   console.log('-- Report --');


### PR DESCRIPTION
## Problem

Every chart/report query computes `total_count` (unique visitors over the whole range) with a **second full scan** of the same WHERE clause — a `_uc` CTE that re-reads the events table and is LEFT ANY JOINed back per breakdown label (or injected as a scalar subquery when there are no breakdowns). On prod this doubles the read cost of every dashboard chart: the top query in last week's Query Insights (a profile-joined chart) reads ~1.03B rows at p50 188s, and even mid-tier charts read 300M+ rows twice.

## Fix

Aggregate `uniqState(profile_id)` alongside the series in the same pass, then merge the per-group states in an outer select with a window aggregate:

```sql
SELECT * EXCEPT (_uc_state), uniqMerge(_uc_state) OVER (PARTITION BY label_1) as total_count
FROM (SELECT ..., count(*) as count, toStartOfDay(created_at) as date,
             properties['x'] as label_1, uniqState(profile_id) as _uc_state
      FROM events_resolved e WHERE ... GROUP BY date, label_1)
ORDER BY date ASC WITH FILL ...
```

`uniq` states merge losslessly, so the result is identical to the two-scan form. Empty partition (no breakdowns) = global total. Response shape is unchanged — `total_count` stays a per-row column, so no consumer changes (consumers read the first truthy `total_count`; FILL-generated rows carry 0 as before).

Also points the main scan at `chartEventsTable` (events_resolved unless profile-filtered). Previously only the `_uc` CTE read the resolved view while the series scanned raw `events`, so per-date uniques and totals disagreed on resolved anonymous profiles.

The now-unneeded `_uc` machinery (inline cohort joins for nested CTEs, `getWhereWithoutBar`) is removed. `where.bar` was never set anywhere, so `_uc`'s WHERE was already identical to the main WHERE.

## Measured on production (closed date range, interleaved repeated runs)

| chart | before | after | correctness |
|---|---|---|---|
| no breakdown | 28.2s / 25.5s, 358M rows | **13.7s / 13.3s, 161M rows** | per-day series + total_count (67,989) identical |
| breakdown on courseStructureSlug | 30.0s / 28.6s | **14.9s / 15.3s** | 1,243 series rows + all per-label totals identical (incl. empty label) |

SQL generated by this branch was also executed against prod verbatim (1,255 rows, 41 labels, single 179M-row scan).

## Tests

`packages/db/src/services/chart-sql.test.ts`: asserts single scan of the events source, `uniqMerge OVER (PARTITION BY label_n)` for breakdowns, ORDER BY/FILL outside the aggregation subquery, and the profile-filtered raw-table path. Full `@openpanel/db` suite passes (36 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)