### PR TITLE
fix(events): bound empty-result lookback to one 7-day fallback

### DIFF
--- a/packages/db/src/services/event.service.ts
+++ b/packages/db/src/services/event.service.ts
@@ -483,7 +483,12 @@ export async function getEventList(options: GetEventListOptions) {
   // stream we keep the resolved view so the displayed profile_id is canonical.
   sb.from = `${profileId || cohortId ? TABLE_NAMES.events : TABLE_NAMES.eventsRead} e`;
 
-  const MAX_DATE_INTERVAL_IN_DAYS = 365;
+  // Newton fork: bound the empty-result lookback to 7 days (was 365 with
+  // window-doubling — up to 11 serial re-queries; on an unindexed properties
+  // filter each wide step full-scanned the table, ~6 min / 530 GiB per page
+  // view when nothing matched). Now a single 7-day fallback after the initial
+  // window; explicit startDate/endDate ranges are unaffected (no cursorWindow).
+  const MAX_DATE_INTERVAL_IN_DAYS = 7;
   // Cap the date interval to prevent infinity
   const safeDateIntervalInDays = Math.min(
     dateIntervalInDays,
@@ -680,7 +685,8 @@ export async function getEventList(options: GetEventListOptions) {
     meta: select.meta ?? true,
   });
 
-  // If we dont get any events, try without the cursor window
+  // If we dont get any events, retry ONCE at the max lookback (no doubling
+  // ladder — a zero-match filter must fail fast, not escalate scans)
   if (
     data.length === 0 &&
     sb.where.cursorWindow &&
@@ -688,7 +694,7 @@ export async function getEventList(options: GetEventListOptions) {
   ) {
     return getEventList({
       ...options,
-      dateIntervalInDays: dateIntervalInDays * 2,
+      dateIntervalInDays: MAX_DATE_INTERVAL_IN_DAYS,
     });
   }
 


### PR DESCRIPTION
## Problem

The events list auto-expands its lookback when a query returns zero rows: 0.5d → 1 → 2 → … → 365d — up to **11 serial re-queries per page view**. On an unindexed `properties` filter, each wide step full-scans the table; a filter matching nothing (the classic "is my just-shipped event arriving?" check) cost **~6 min / 530 GiB per page view** and the page hung on skeletons. This was the Jul 10 "dashboard not loading" report; five complete cascades were caught in a single day's `query_log` (2.66 TB read — the service's #1 workload). The same expansion fires from infinite-scroll cursor slices, so merely scrolling past the last matching event of a filtered stream triggered one more full cascade.

## Change

- Initial window unchanged (12h default).
- On zero rows: **one** fallback query at 7 days, then return empty — no doubling ladder.
- Explicit `startDate`/`endDate` ranges: unaffected (they never had a cursor window and never expanded).
- Scroll gap-hopping bounded the same way: a >7-day gap now ends the list instead of escalating scans.

Measured windows on prod for this filter class: 12h = 45 ms, 4d = 0.3 s, so the worst case per page view drops from ~6 min of serial scans to two sub-second queries. The remaining cost of the 7-day probe shrinks further once the `properties['eventName']` bloom index (#16) is materialized.

Full `@openpanel/db` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)