### PR TITLE
perf(ch): eventName bloom index (migration 22) + scalar-key funnel profile join

### DIFF
--- a/packages/db/code-migrations/22-eventname-bloom-index.admin.sql
+++ b/packages/db/code-migrations/22-eventname-bloom-index.admin.sql
@@ -1,0 +1,44 @@
+-- Newton fork: ADMIN one-time step for migration 22 (properties['eventName'] bloom index).
+--
+-- Migration 22 (22-eventname-bloom-index.ts) only ADDs the index, which applies
+-- to newly-written parts. Existing parts must be backfilled with MATERIALIZE
+-- INDEX. Unlike the profile_id index (migration 17), building this one reads
+-- the fat `properties` Map column (~500 GiB uncompressed across the table), so
+-- it is run MANUALLY, PARTITION BY PARTITION (monthly, toYYYYMM), for control
+-- over load — NOT in one table-wide mutation and NOT in the code migration.
+--
+-- Run as openpanel_writer (has ALTER on openpanel.*) against the INGESTION
+-- service (always-on; mutations are background — SELECTs/INSERTs unaffected,
+-- just extra CPU/IO). The index files land in shared storage, so the analytics
+-- replica prunes with them too. Off-peak recommended.
+--
+-- ── Phase 0: pilot one recent partition and MEASURE before rolling the rest ──
+
+ALTER TABLE openpanel.events MATERIALIZE INDEX idx_properties_event_name IN PARTITION '202607';
+
+-- Wait for is_done=1:
+--   SELECT mutation_id, is_done, parts_to_do, latest_fail_reason
+--   FROM system.mutations
+--   WHERE table = 'events' AND command LIKE '%idx_properties_event_name%'
+--   ORDER BY create_time DESC;
+--
+-- Then measure pruning on the pilot partition (compare granules dropped):
+--   EXPLAIN indexes = 1
+--   SELECT count() FROM openpanel.events
+--   WHERE project_id = 'platform' AND name = 'log'
+--     AND properties['eventName'] = 'koyoInterviewPage_networkStatusChanged'
+--     AND toYYYYMM(created_at) = 202607;
+-- Expect idx_properties_event_name to drop nearly all granules for rare values.
+-- Also time the same query with/without `SETTINGS use_skip_indexes = 0` for a
+-- direct before/after on identical data.
+--
+-- ── Phase 1: roll remaining partitions, oldest data optional ──
+-- List partitions:
+--   SELECT partition, sum(rows) AS rows, formatReadableSize(sum(data_compressed_bytes)) AS size
+--   FROM system.parts WHERE database = 'openpanel' AND table = 'events' AND active
+--   GROUP BY partition ORDER BY partition;
+--
+-- Then one at a time (wait for is_done=1 between each):
+--   ALTER TABLE openpanel.events MATERIALIZE INDEX idx_properties_event_name IN PARTITION '<yyyymm>';
+--
+-- Status: not yet run on prod.

--- a/packages/db/code-migrations/22-eventname-bloom-index.ts
+++ b/packages/db/code-migrations/22-eventname-bloom-index.ts
@@ -1,0 +1,43 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { runClickhouseMigrationCommands } from '../src/clickhouse/migration';
+
+/**
+ * Newton fork: data-skipping index on properties['eventName'].
+ *
+ * Koyo-style telemetry sends every event as name='log' (62M+ rows) with the
+ * real event name in properties.eventName, so name-based pruning never helps
+ * those queries. Filtering on properties['eventName'] must then decompress the
+ * entire properties Map for every candidate row — a full-retention filter read
+ * 1.35B rows / 528 GiB in ~176s on the analytics replica, and the events page's
+ * lookback expansion re-ran that class of scan up to 11× per page view.
+ *
+ * A bloom_filter index on the map element lets granule pruning skip parts that
+ * can't contain the value (same pattern as the existing idx_properties_bounce
+ * set index). Rare values collapse to a handful of granules; frequent values
+ * are unchanged. Skip indexes can only over-read, never alter results.
+ *
+ * This migration only ADDs the index (cheap, metadata-level, idempotent) so new
+ * parts index on insert/merge. Existing parts need MATERIALIZE INDEX — a heavy
+ * one-time mutation over the fat properties column, kept OUT of the migration
+ * and run manually partition-by-partition for control. See the companion
+ * `22-eventname-bloom-index.admin.sql` runbook (pilot one partition, measure,
+ * then roll the rest). Fresh installs need no backfill.
+ */
+
+const DB = 'openpanel';
+
+export async function up() {
+  const sqls = [
+    `ALTER TABLE ${DB}.events ADD INDEX IF NOT EXISTS idx_properties_event_name properties['eventName'] TYPE bloom_filter(0.01) GRANULARITY 1`,
+  ];
+
+  fs.writeFileSync(
+    path.join(import.meta.filename.replace('.ts', '.sql')),
+    sqls.map((sql) => sql.trim().replace(/;$/, '').concat(';')).join('\n\n---\n\n')
+  );
+
+  if (!process.argv.includes('--dry')) {
+    await runClickhouseMigrationCommands(sqls);
+  }
+}

--- a/packages/db/src/services/chart.service.ts
+++ b/packages/db/src/services/chart.service.ts
@@ -272,7 +272,7 @@ export function getSelectPropertyKey(
 // the shared key helpers (used by funnel/conversion/overview) are untouched.
 const PROFILE_PROP_PREFIX = 'profile.properties.';
 
-function collectProfilePropertyKeys(
+export function collectProfilePropertyKeys(
   refs: { name: string }[],
 ): { keys: string[]; hasWildcard: boolean } {
   const keys = new Set<string>();
@@ -290,7 +290,7 @@ function collectProfilePropertyKeys(
 
 // Build the profile-CTE SELECT expression for the `properties` field: one scalar column per
 // referenced key, plus the full Map only when a wildcard ref needs it (or nothing specific).
-function profilePropertiesCteSelect(
+export function profilePropertiesCteSelect(
   keys: string[],
   hasWildcard: boolean,
 ): string {
@@ -306,7 +306,7 @@ function profilePropertiesCteSelect(
 // Rewrite `profile.properties['<key>']` -> `` `profile.properties.<key>` `` for the narrowed
 // keys (matches the raw render from transformPropertyKey/getSelectPropertyKey; never matches
 // the CTE's own `properties['<key>']`, which has no `profile.` prefix). No-op when keys=[].
-function rewriteProfilePropertyRefs(sql: string, keys: string[]): string {
+export function rewriteProfilePropertyRefs(sql: string, keys: string[]): string {
   let out = sql;
   for (const k of keys) {
     out = out.split(`profile.properties['${k}']`).join(`\`profile.properties.${k}\``);

--- a/packages/db/src/services/funnel-sql.test.ts
+++ b/packages/db/src/services/funnel-sql.test.ts
@@ -54,3 +54,53 @@ describe('funnel CTE events alias', () => {
     expect(sql).toContain('FROM events AS events');
   });
 });
+
+// The profiles join must only carry the referenced property keys as scalar
+// columns — joining every profile's whole properties Map costs multi-GiB per
+// funnel. Conditions are rewritten to the scalar aliases via
+// profilePropertyKeys (same mechanism as the chart profile CTE).
+describe('funnel profile-property scalar rewrite', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubEnv('NEWTON_RESOLVE_PROFILE', '1');
+  });
+
+  it('rewrites profile.properties refs in funnel conditions to scalar aliases', async () => {
+    const { funnelService } = await import('./funnel.service');
+    const sql = funnelService
+      .buildFunnelCte({
+        projectId: 'p1',
+        startDate: '2026-06-01 00:00:00',
+        endDate: '2026-06-02 00:00:00',
+        eventSeries: [
+          {
+            id: '1',
+            name: 'sign_up',
+            displayName: 'sign_up',
+            segment: 'event',
+            filters: [
+              {
+                id: 'f1',
+                name: 'profile.properties.plan',
+                operator: 'is',
+                value: ['pro'],
+              },
+            ],
+          },
+          eventSeries[1]!,
+        ],
+        funnelWindowMilliseconds: 86_400_000,
+        timezone: 'UTC',
+        profilePropertyKeys: ['plan'],
+      })
+      .toSQL();
+    expect(sql).toContain('`profile.properties.plan`');
+    expect(sql).not.toContain("profile.properties['plan']");
+  });
+
+  it('leaves conditions untouched when no keys are passed', async () => {
+    const { funnelService } = await import('./funnel.service');
+    const sql = buildFunnelSql(funnelService);
+    expect(sql).not.toContain('`profile.properties.');
+  });
+});

--- a/packages/db/src/services/funnel.service.ts
+++ b/packages/db/src/services/funnel.service.ts
@@ -9,10 +9,13 @@ import { createSqlBuilder } from '../sql-builder';
 import {
   buildInlineCohortJoin,
   collectCohortIds,
+  collectProfilePropertyKeys,
   extractCohortId,
   fetchCohortsMetadata,
   getEventFiltersWhereClause,
   getSelectPropertyKey,
+  profilePropertiesCteSelect,
+  rewriteProfilePropertyRefs,
 } from './chart.service';
 import { onlyReportEvents } from './reports.service';
 
@@ -64,6 +67,7 @@ export class FunnelService {
     additionalSelects = [],
     additionalGroupBy = [],
     group = 'session_id',
+    profilePropertyKeys = [],
   }: {
     projectId: string;
     startDate: string;
@@ -74,8 +78,11 @@ export class FunnelService {
     additionalSelects?: string[];
     additionalGroupBy?: string[];
     group?: 'session_id' | 'profile_id';
+    profilePropertyKeys?: string[];
   }) {
-    const funnels = this.getFunnelConditions(eventSeries, projectId);
+    const funnels = this.getFunnelConditions(eventSeries, projectId).map((c) =>
+      rewriteProfilePropertyRefs(c, profilePropertyKeys),
+    );
     const primaryKey = group === 'profile_id' ? 'profile_id' : 'session_id';
     // Newton fork: match Mixpanel's default (non-strict) funnel ordering — consecutive
     // steps require created_at >= prev, not strictly >. OP events carry distinct ms
@@ -265,6 +272,15 @@ export class FunnelService {
     const cohortIds = collectCohortIds(allFilters, breakdowns);
     const cohortMetadata = await fetchCohortsMetadata(cohortIds);
 
+    // Newton fork: join only the referenced profile-property keys as scalar
+    // columns instead of every profile's whole properties Map (multi-GiB on the
+    // events×profiles join — same fix as the chart profile CTE). References in
+    // funnel conditions/breakdowns are rewritten to the scalar aliases below.
+    const profileProps = collectProfilePropertyKeys([
+      ...allFilters,
+      ...breakdowns,
+    ]);
+
     // Create the funnel CTE (session-level)
     //
     // Newton fork: attribute each breakdown to the value at the FIRST funnel
@@ -276,16 +292,17 @@ export class FunnelService {
     // windowFunnel sequence never connects, and downstream steps show 0. Reading
     // the entry-step value keeps each user's sequence intact in one group and
     // matches standard funnel-breakdown semantics (segment by entry attribute).
-    const funnelConditions = this.getFunnelConditions(eventSeries, projectId);
+    const funnelConditions = this.getFunnelConditions(
+      eventSeries,
+      projectId,
+    ).map((c) => rewriteProfilePropertyRefs(c, profileProps.keys));
     const firstStepCondition = funnelConditions[0]!;
     const breakdownSelects = breakdowns.map((b, index) => {
       const bId = extractCohortId(b.name);
       const bName = bId ? cohortMetadata.get(bId)?.name : undefined;
-      const expr = getSelectPropertyKey(
-        b.name,
-        projectId,
-        bId ?? undefined,
-        bName,
+      const expr = rewriteProfilePropertyRefs(
+        getSelectPropertyKey(b.name, projectId, bId ?? undefined, bName),
+        profileProps.keys,
       );
       return `argMinIf(${expr}, created_at, ${firstStepCondition}) as b_${index}`;
     });
@@ -299,25 +316,38 @@ export class FunnelService {
       timezone,
       additionalSelects: breakdownSelects,
       group,
+      profilePropertyKeys: profileProps.keys,
     });
 
     if (anyFilterOnProfile || anyBreakdownOnProfile) {
-      // Collect profile columns needed for filters and breakdowns (same as conversion.service)
+      // Collect profile columns needed for filters and breakdowns. Scalar
+      // columns (email etc.) are selected as-is; the properties Map is narrowed
+      // to the referenced keys via profilePropertiesCteSelect — joining the
+      // whole Map of every profile costs multi-GiB per funnel.
       const profileFields = new Set<string>(['id']);
       for (const f of profileFilters) {
-        profileFields.add(f.split('.')[0]!);
+        const fieldName = f.split('.')[0]!;
+        if (fieldName !== 'properties') {
+          profileFields.add(fieldName);
+        }
       }
       for (const b of breakdowns.filter((x) => x.name.startsWith('profile.'))) {
         const fieldName = b.name.replace('profile.', '').split('.')[0];
-        if (fieldName === 'properties') {
-          profileFields.add('properties');
-        } else if (['email', 'first_name', 'last_name'].includes(fieldName!)) {
+        if (['email', 'first_name', 'last_name'].includes(fieldName!)) {
           profileFields.add(fieldName!);
         }
       }
-      const profileSelectColumns = Array.from(profileFields).join(', ');
+      const selectColumns = Array.from(profileFields);
+      const referencesProperties =
+        profileFilters.some((f) => f.startsWith('properties')) ||
+        breakdowns.some((b) => b.name.startsWith('profile.properties'));
+      if (referencesProperties) {
+        selectColumns.push(
+          profilePropertiesCteSelect(profileProps.keys, profileProps.hasWildcard),
+        );
+      }
       funnelCte.leftJoin(
-        `(SELECT ${profileSelectColumns} FROM ${TABLE_NAMES.profiles} FINAL
+        `(SELECT ${selectColumns.join(', ')} FROM ${TABLE_NAMES.profiles} FINAL
           WHERE project_id = ${sqlstring.escape(projectId)}) as profile`,
         'profile.id = events.profile_id',
       );


### PR DESCRIPTION
Re-opened #16 after its stacked base (#15) merged and the branch auto-closed it. Same content — see #16 for the full description and prod measurements: migration 22 adds the properties['eventName'] bloom index (ADD-only; manual partition-wise backfill runbook in 22-eventname-bloom-index.admin.sql, pilot-first), and funnels join only referenced profile-property keys as scalars (measured 14.9s→8.2s, 6.02→5.33 GiB, identical funnel levels).

🤖 Generated with [Claude Code](https://claude.com/claude-code)