### PR TITLE
fix(trpc): list all profile property keys instead of sampling profiles

### DIFF
--- a/packages/trpc/src/routers/chart.ts
+++ b/packages/trpc/src/routers/chart.ts
@@ -235,6 +235,7 @@ export const chartRouter = createTRPCRouter({
     }),
 
   properties: protectedProcedure
+    .use(cacheMiddleware(60 * 5))
     .input(
       z.object({
         event: z.string().optional(),
@@ -242,21 +243,28 @@ export const chartRouter = createTRPCRouter({
       })
     )
     .query(async ({ input: { projectId, event } }) => {
-      const profiles = await clix(ch, 'UTC')
-        .select<Pick<IServiceProfile, 'properties'>>(['properties'])
+      // Profile property keys have to come from an aggregate over every
+      // profile, not a sample of rows. `LIMIT n` on profiles only reveals the
+      // keys that happen to live in those n rows, so a property set on a small
+      // share of profiles was usually missing from breakdown/filter pickers —
+      // and because the sample had no ORDER BY, which rows came back varied
+      // with read scheduling, so the property appeared and vanished between
+      // requests. The LIMIT below caps the returned KEY list rather than the
+      // rows scanned, so it cannot hide a rare key.
+      const profileKeys = await clix(ch, 'UTC')
+        .select<{ key: string }>([
+          'DISTINCT arrayJoin(mapKeys(properties)) AS key',
+        ])
         .from(TABLE_NAMES.profiles)
         .where('project_id', '=', projectId)
         .where('is_external', '=', true)
+        .orderBy('key', 'ASC')
         .limit(10_000)
         .execute();
 
-      const profileProperties = [
-        ...new Set(
-          profiles.flatMap((p) =>
-            Object.keys(p.properties).map((k) => `profile.properties.${k}`)
-          )
-        ),
-      ];
+      const profileProperties = profileKeys.map(
+        (r) => `profile.properties.${r.key}`
+      );
 
       const query = clix(ch)
         .select<{ property_key: string; created_at: string }>([


### PR DESCRIPTION
Fixes NS-13449. Upstream issue: https://github.com/Openpanel-dev/openpanel/issues/423

## Problem

Amol reported that the profile property `ds_trial_lms_home_information_pop_change_experiment` never showed up in a funnel breakdown dropdown, appearing "a couple of times randomly after a lot of wait."

It is not a load issue. `chart.properties` built the profile-property list from an **unordered `LIMIT 10_000`** over `profiles`, then unioned the map keys of whatever rows came back:

```ts
.from(TABLE_NAMES.profiles)
.where('is_external', '=', true)
.limit(10_000)          // no ORDER BY
```

On `platform` that samples 0.33% of **3,035,330** identified profiles. The property is set on **1,077** of them (0.035%), so it was usually invisible. And because `LIMIT` without `ORDER BY` returns whichever rows the reading threads emit first, the list changed between requests — hence the intermittency.

Measured on identical data by varying `max_threads`:

| `max_threads` | profile keys offered | property present? |
|---|---|---|
| 1 | 27 | **no** |
| 2 | 182 | yes |
| 12 | 234 | yes |
| 32 | 166 | yes |

The project actually has **404** distinct profile-property keys.

## Fix

Replace the row sample with an aggregate, mirroring the existing `getGroupPropertyKeys` in `packages/db/src/services/group.service.ts`:

```sql
SELECT DISTINCT arrayJoin(mapKeys(properties)) AS key
FROM profiles
WHERE project_id = ? AND is_external = true
ORDER BY key LIMIT 10000
```

Proof it is no longer sampling — same worst case, `max_threads=1`:

| | rows scanned | keys found | rare key |
|---|---|---|---|
| before | 37,420 | 27 | no |
| after | **5,542,136** | **404** | **yes** |

The `LIMIT` now caps the returned **key list**, not the rows scanned, so it cannot hide a rare key. At 404 keys it leaves 25x headroom while bounding the response payload (~45 bytes/key, so the cap is ~450KB — comparable to the existing event-key half at 395KB). `ORDER BY key` keeps it deterministic if the ceiling is ever reached.

Verified identical output at `max_threads` 1, 4 and 16.

## Caching

Cost goes 137ms -> 748ms, so the procedure is now cached for 5 minutes via `cacheMiddleware(60 * 5)`, matching what `projectCard` already does. That holds it to at most one ClickHouse query per project per 5 minutes, shared across users and pods via Redis.

Deliberately **not** changing the shared `cacher` binding (`chart.ts:62`, 60s), which is used by funnel/conversion/chart/aggregate/cohort — bumping that would change freshness for every chart in the product.

I also checked the ClickHouse query cache as an alternative: it works (756ms -> 30ms, TTL 60s) but `arrayJoin` is classed as non-deterministic, so with the default `query_cache_nondeterministic_function_handling = throw` any such query **fails** with error 704 rather than skipping the cache. Enabling it globally would be risky, and Redis caches the whole response including the 395KB event-key half. Noted here so nobody enables it without knowing.

## No UI change needed

`PropertiesCombobox` already filters with a substring `includes()` match, so partial search ("information") finds the property as soon as it is in the list. Amol's original request to "match part of the string" needs no code — the item was simply absent from the array.

## Scope notes

- Upstream has this identical bug; the fix here matches what I proposed in openpanel#423, so this hunk should resolve cleanly (or drop out) when they land it.
- **Not fixed here:** the event-property half of the same procedure uses `ORDER BY length(property_key) ASC ... LIMIT 10_000`. `platform` is at **8,064** distinct event keys and grew ~25% in six weeks; when it crosses 10,000 the *longest* keys get silently dropped first. Worth a follow-up before then.
- A materialized view (like `event_property_values_mv` does for event keys) would be the architecturally cleaner answer and would cut this to ~20ms, but it needs a new table, a migration and an 8.6M-row backfill, and would be a permanent fork divergence. Deferred; revisit if profile count grows enough that 748ms becomes multi-second (it is linear), or if upstream declines the fix.

## Testing

- `pnpm --filter @openpanel/trpc typecheck` passes
- Query shape validated directly against production ClickHouse (404 keys returned, rare key present, deterministic across thread counts)
- Not yet exercised end-to-end in the running dashboard — worth a click-through on staging: open a funnel report, add a breakdown, search "information" under **Profile properties**.
