### PR TITLE
fix(cohorts): compute property cohorts without FINAL so they stop OOMing

### DIFF
--- a/packages/db/src/services/cohort-property-sql.test.ts
+++ b/packages/db/src/services/cohort-property-sql.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import type { PropertyBasedCohortDefinition } from '@openpanel/validation';
+
+async function buildSql(
+  criteria: PropertyBasedCohortDefinition['criteria'],
+  limit?: number,
+) {
+  const { buildPropertyBasedCohortQuery } = await import('./cohort.service');
+  return buildPropertyBasedCohortQuery(
+    'p1',
+    { type: 'property', criteria } as PropertyBasedCohortDefinition,
+    limit,
+  );
+}
+
+const mapFilter = {
+  id: 'a',
+  name: 'profile.properties.experiment',
+  operator: 'is' as const,
+  value: ['control'],
+};
+
+describe('buildPropertyBasedCohortQuery', () => {
+  it('resolves the newest row per profile without FINAL', async () => {
+    const sql = await buildSql({ operator: 'and', properties: [mapFilter] });
+
+    // FINAL cannot spill to disk and needed 2.4-3.0GiB on this table.
+    expect(sql).not.toContain('FINAL');
+    expect(sql).toContain('GROUP BY id');
+    expect(sql).toContain(
+      "argMax(profiles.properties['experiment'], tuple(created_at, profiles.properties['experiment']))",
+    );
+  });
+
+  it('filters aggregates in HAVING, not WHERE', async () => {
+    const sql = await buildSql({ operator: 'and', properties: [mapFilter] });
+
+    const having = sql.indexOf('HAVING');
+    expect(having).toBeGreaterThan(-1);
+    expect(sql.indexOf('argMax')).toBeGreaterThan(having);
+  });
+
+  it('wraps plain columns too, so mixed cohorts stay on one scan', async () => {
+    const sql = await buildSql({
+      operator: 'or',
+      properties: [
+        mapFilter,
+        { id: 'b', name: 'profile.email', operator: 'contains' as const, value: ['ns'] },
+      ],
+    });
+
+    expect(sql).toContain('argMax(profiles.email, tuple(created_at,');
+    expect(sql).toContain(' OR ');
+    expect(sql).not.toContain('FINAL');
+  });
+
+  it('applies the limit', async () => {
+    const sql = await buildSql({ operator: 'and', properties: [mapFilter] }, 10);
+
+    expect(sql).toContain('LIMIT 10');
+  });
+
+  it('matches nothing when every filter was dropped as empty', async () => {
+    const sql = await buildSql({
+      operator: 'and',
+      properties: [{ id: 'a', name: 'profile.properties.x', operator: 'is' as const, value: [] }],
+    });
+
+    expect(sql).toContain('WHERE 1=0');
+    expect(sql).not.toContain('argMax');
+  });
+});

--- a/packages/db/src/services/cohort-property-sql.test.ts
+++ b/packages/db/src/services/cohort-property-sql.test.ts
@@ -60,6 +60,18 @@ describe('buildPropertyBasedCohortQuery', () => {
     expect(sql).toContain('LIMIT 10');
   });
 
+  it('keeps the spill threshold below the hard memory limit', async () => {
+    const { PROFILE_COHORT_QUERY_SETTINGS } = await import('./cohort.service');
+    const spill = Number(
+      PROFILE_COHORT_QUERY_SETTINGS.max_bytes_before_external_group_by,
+    );
+    const limit = Number(PROFILE_COHORT_QUERY_SETTINGS.max_memory_usage);
+
+    // Above the limit the query is killed before it ever writes to disk.
+    expect(spill).toBe(314_572_800);
+    expect(limit).toBeGreaterThan(spill);
+  });
+
   it('matches nothing when every filter was dropped as empty', async () => {
     const sql = await buildSql({
       operator: 'and',

--- a/packages/db/src/services/cohort.service.ts
+++ b/packages/db/src/services/cohort.service.ts
@@ -9,6 +9,7 @@ import type {
   Timeframe,
 } from '@openpanel/validation';
 
+import type { ClickHouseSettings } from '@clickhouse/client';
 import { cohortComputeQueue } from '@openpanel/queue';
 import { TABLE_NAMES, ch, chQuery } from '../clickhouse/client';
 import { db } from '../prisma-client';
@@ -30,6 +31,18 @@ export const COHORT_MATERIALIZE_LIMIT = Number.parseInt(
   process.env.COHORT_MATERIALIZE_LIMIT ?? '10000',
   10,
 );
+
+// Newton fork: property cohorts aggregate every profile row for the project, so
+// they are the one cohort query that can outgrow the server's memory headroom.
+// The spill threshold has to stay well below the hard limit — a GROUP BY only
+// starts writing to disk once it crosses it, so a threshold above the limit
+// means the query dies before it ever spills. Measured on 8.3M profiles:
+// ~281MB spills either way, peak 695MiB at this threshold versus 2.4-3.0GiB for
+// the FINAL form these queries used to take, which cannot spill at all.
+const PROFILE_COHORT_QUERY_SETTINGS: ClickHouseSettings = {
+  max_bytes_before_external_group_by: '536870912',
+  max_memory_usage: '1400000000',
+};
 
 // Newton fork: cohort criteria are evaluated on the RESOLVED identity — the
 // raw profile_id folded through the device_alias dictionary, exactly like the
@@ -180,27 +193,40 @@ export function buildEventCriteriaQuery(
   `;
 }
 
-export function buildPropertyBasedCohortQuery(
-  projectId: string,
+function buildProfileCohortHavingClause(
   definition: PropertyBasedCohortDefinition,
-): string {
+): string | null {
   const { properties, operator } = definition.criteria;
-  const filterWhere = getProfileFiltersWhereClause(properties);
+  const filterWhere = getProfileFiltersWhereClause(properties, {
+    latestPerProfile: true,
+  });
   const filterClauses = Object.values(filterWhere);
 
   if (filterClauses.length === 0) {
-    return `SELECT id as profile_id FROM ${TABLE_NAMES.profiles} FINAL WHERE 1=0`;
+    return null;
   }
 
-  const filterClause = filterClauses.join(
-    operator === 'and' ? ' AND ' : ' OR ',
-  );
+  return filterClauses.join(operator === 'and' ? ' AND ' : ' OR ');
+}
+
+export function buildPropertyBasedCohortQuery(
+  projectId: string,
+  definition: PropertyBasedCohortDefinition,
+  limit?: number,
+): string {
+  const havingClause = buildProfileCohortHavingClause(definition);
+
+  if (!havingClause) {
+    return `SELECT id as profile_id FROM ${TABLE_NAMES.profiles} WHERE 1=0`;
+  }
 
   return `
     SELECT id as profile_id
-    FROM ${TABLE_NAMES.profiles} FINAL
+    FROM ${TABLE_NAMES.profiles}
     WHERE project_id = ${sqlstring.escape(projectId)}
-      AND (${filterClause})
+    GROUP BY id
+    HAVING (${havingClause})
+    ${limit ? `LIMIT ${limit}` : ''}
   `;
 }
 
@@ -248,6 +274,7 @@ export async function countEventBasedCohort(
 
 function getProfileFiltersWhereClause(
   filters: IChartEventFilter[],
+  { latestPerProfile = false }: { latestPerProfile?: boolean } = {},
 ): Record<string, string> {
   const where: Record<string, string> = {};
 
@@ -271,6 +298,16 @@ function getProfileFiltersWhereClause(
       columnAccess = `profiles.properties['${propKey}']`;
     } else {
       columnAccess = normalizedName;
+    }
+
+    if (latestPerProfile) {
+      // Resolve the profile's newest row inside a GROUP BY instead of reading
+      // through FINAL. created_at is the table's version column but it is not
+      // unique — duplicate rows routinely share one — so it is paired with the
+      // value itself to break ties deterministically. FINAL breaks the same
+      // ties by part order, which is not derivable from the data and can shift
+      // under a background merge.
+      columnAccess = `argMax(${columnAccess}, tuple(created_at, ${columnAccess}))`;
     }
 
     switch (operator) {
@@ -373,27 +410,14 @@ export async function computePropertyBasedCohort(
   definition: PropertyBasedCohortDefinition,
   limit?: number,
 ): Promise<string[]> {
-  const { properties, operator } = definition.criteria;
-  const filterWhere = getProfileFiltersWhereClause(properties);
-  const filterClauses = Object.values(filterWhere);
-
-  if (filterClauses.length === 0) {
+  if (!buildProfileCohortHavingClause(definition)) {
     return [];
   }
 
-  const filterClause = filterClauses.join(
-    operator === 'and' ? ' AND ' : ' OR ',
+  const results = await chQuery<{ profile_id: string }>(
+    buildPropertyBasedCohortQuery(projectId, definition, limit),
+    PROFILE_COHORT_QUERY_SETTINGS,
   );
-
-  const query = `
-    SELECT id as profile_id
-    FROM ${TABLE_NAMES.profiles} FINAL
-    WHERE project_id = ${sqlstring.escape(projectId)}
-      AND (${filterClause})
-    ${limit ? `LIMIT ${limit}` : ''}
-  `;
-
-  const results = await chQuery<{ profile_id: string }>(query);
   return results.map((r) => r.profile_id);
 }
 
@@ -401,26 +425,14 @@ export async function countPropertyBasedCohort(
   projectId: string,
   definition: PropertyBasedCohortDefinition,
 ): Promise<number> {
-  const { properties, operator } = definition.criteria;
-  const filterWhere = getProfileFiltersWhereClause(properties);
-  const filterClauses = Object.values(filterWhere);
-
-  if (filterClauses.length === 0) {
+  if (!buildProfileCohortHavingClause(definition)) {
     return 0;
   }
 
-  const filterClause = filterClauses.join(
-    operator === 'and' ? ' AND ' : ' OR ',
+  const results = await chQuery<{ count: number }>(
+    `SELECT count() as count FROM (${buildPropertyBasedCohortQuery(projectId, definition)})`,
+    PROFILE_COHORT_QUERY_SETTINGS,
   );
-
-  const query = `
-    SELECT count() as count
-    FROM ${TABLE_NAMES.profiles} FINAL
-    WHERE project_id = ${sqlstring.escape(projectId)}
-      AND (${filterClause})
-  `;
-
-  const results = await chQuery<{ count: number }>(query);
   return results[0]?.count ?? 0;
 }
 

--- a/packages/db/src/services/cohort.service.ts
+++ b/packages/db/src/services/cohort.service.ts
@@ -34,14 +34,34 @@ export const COHORT_MATERIALIZE_LIMIT = Number.parseInt(
 
 // Newton fork: property cohorts aggregate every profile row for the project, so
 // they are the one cohort query that can outgrow the server's memory headroom.
-// The spill threshold has to stay well below the hard limit — a GROUP BY only
-// starts writing to disk once it crosses it, so a threshold above the limit
-// means the query dies before it ever spills. Measured on 8.3M profiles:
-// ~281MB spills either way, peak 695MiB at this threshold versus 2.4-3.0GiB for
-// the FINAL form these queries used to take, which cannot spill at all.
-const PROFILE_COHORT_QUERY_SETTINGS: ClickHouseSettings = {
-  max_bytes_before_external_group_by: '536870912',
-  max_memory_usage: '1400000000',
+// Past this many bytes the GROUP BY writes to disk instead of growing; raising
+// it trades headroom for very little time, because the volume spilled is set by
+// the data rather than by the threshold (measured on 8.3M profiles: ~281MB
+// spilled at a 300MB, 512MB or 768MB threshold, 6.9s/6.7s/6.0s, while peak
+// memory climbs 410MiB/695MiB/893MiB). Env-tunable so it can be retuned without
+// an image rebuild, same as COHORT_MATERIALIZE_LIMIT.
+const COHORT_QUERY_SPILL_BYTES_RAW = Number.parseInt(
+  process.env.COHORT_QUERY_SPILL_BYTES ?? '314572800',
+  10,
+);
+const COHORT_QUERY_SPILL_BYTES = Number.isNaN(COHORT_QUERY_SPILL_BYTES_RAW)
+  ? 314_572_800
+  : COHORT_QUERY_SPILL_BYTES_RAW;
+
+// A GROUP BY only starts spilling once it crosses the threshold, so the hard
+// limit has to stay above it — otherwise the query is killed before it ever
+// writes to disk. That inversion is exactly what ClickHouse Cloud ships by
+// default (a 4GiB threshold against a ceiling reached at 2.4-3.0GiB), and it is
+// why nothing spilled before. Derived from the threshold so retuning the env var
+// cannot reintroduce it.
+const COHORT_QUERY_MEMORY_LIMIT_BYTES = Math.max(
+  1_400_000_000,
+  COHORT_QUERY_SPILL_BYTES * 3,
+);
+
+export const PROFILE_COHORT_QUERY_SETTINGS: ClickHouseSettings = {
+  max_bytes_before_external_group_by: String(COHORT_QUERY_SPILL_BYTES),
+  max_memory_usage: String(COHORT_QUERY_MEMORY_LIMIT_BYTES),
 };
 
 // Newton fork: cohort criteria are evaluated on the RESOLVED identity — the


### PR DESCRIPTION
Follow-up to #20. That PR unfroze the `cohortRefresh` cron; this fixes the three cohorts that then started failing every tick.

## Problem

Three of six cohorts fail on every 30-minute tick with:

```
(total) memory limit exceeded: would use 7.21 GiB, current RSS: 7.20 GiB, maximum: 7.20 GiB
OvercommitTracker decision: Query was selected to stop ... (while reading column properties)
```

The instance is **8 GiB** (tracker cap 7.20 GiB) with a **~4.7 GiB idle baseline** — zero merges, zero queries, of which ~2.2 GiB is jemalloc retained rather than live data. That leaves ~2.4 GiB of headroom against a query wanting 2.4–3.0 GiB.

The split isn't property-vs-event cohorts. `NS employees` is a property cohort too and works fine at **687 MiB** — it filters `profile.email`, a plain String column. The three failures all filter a `properties['key']` **Map**, and reading one Map key requires reading every key and value for every row scanned.

Because the OvercommitTracker kills a *victim* rather than the hog, these queries also take down unrelated ones — during investigation a trivial 12 MiB allocation was killed.

## `FINAL` is the cost — measured, not assumed

| Variant | Peak | Result |
|---|---|---|
| `FINAL` (as shipped) | 2.42–3.02 GiB | fails |
| `FINAL` + `max_threads` 1 / 2 / 4 | 2.42 / 2.74 / 2.68 GiB | fails — threads irrelevant |
| `FINAL` + `do_not_merge_across_partitions_select_final=1` | >2.5 GiB | fails |
| `FINAL` + two-phase `id IN (candidates)` | 2.80 GiB | fails — IN-set doesn't prune the merge |
| **GROUP BY + argMax** | **695 MiB** | **works** |

Not the Map read, not parallelism. `FINAL` on `SharedReplacingMergeTree` merges globally across 167 parts / 45 partitions, and **it cannot spill** — which is why it dies outright instead of slowing down.

## Fix

Resolve each profile's newest row inside a `GROUP BY` instead of reading through `FINAL`:

```sql
SELECT id as profile_id FROM profiles
WHERE project_id = 'x'
GROUP BY id
HAVING (argMax(properties['k'], tuple(created_at, properties['k'])) IN ('a','b'))
```

Verified against production data — all three previously-failing cohorts now complete:

| Cohort | Result |
|---|---|
| `Is MQL for NST (2025/26)` | 77,630 members |
| `lms home information experiment control` | 551 |
| `lms home information experiment variant` | 535 |

And three run **concurrently** without moving server memory (4.88 → 4.80 GiB).

### On the tie-break

`created_at` is the version column but is **not unique** — e.g. profile `6FNXFNDODT` has three rows all at `2025-05-26 12:45:42.000` with two different emails. So "the latest row" is genuinely ambiguous, and pairing `created_at` with the value makes the choice deterministic.

`FINAL` breaks the same ties by **part order**, which isn't derivable from the data and can shift under a background merge — so membership for tied profiles was never stable. On the email cohort, measured at the same instant: `FINAL` 1613, this 1604, differing on 10 ids (~0.6%). Plain `argMax` without the tuple differed on 16 and returned different answers between runs minutes apart. This trades exact agreement with an arbitrary choice for an answer that stops changing between ticks.

### On the spill threshold

```ts
max_bytes_before_external_group_by: COHORT_QUERY_SPILL_BYTES  // default 300 MB
max_memory_usage: max(1.4 GB, spill * 3)                      // derived
```

There's no boolean spill flag — the threshold *is* the switch, and it must sit **below** the hard limit, because a GROUP BY only starts writing to disk once it crosses the threshold. Cloud ships a 4 GiB threshold against a ceiling reached at 2.4-3.0 GiB, so nothing ever spilled. A/B on the same query with an identical 900 MB cap: no threshold -> dies at 912 MiB; threshold 300 MB -> succeeds, peak 410 MiB, 281 MB written to disk.

The hard limit is **derived from** the threshold rather than fixed, so retuning the env var cannot reintroduce that inversion.

Raising the threshold buys little, because the volume spilled is set by the data rather than by the threshold:

| Threshold | Peak | Spilled | Duration |
|---|---|---|---|
| **300 MB (default)** | 410 MiB | 281.0 MB | 6860 ms |
| 512 MB | 695 MiB | 280.9 MB | 6741 ms |
| 768 MB | 893 MiB | 280.6 MB | 5953 ms |

300 MB is the default: on an instance with ~2.4 GiB of headroom that intermittently pins at its ceiling, +70% peak memory for ~2% time is the wrong trade. `COHORT_QUERY_SPILL_BYTES` retunes it without an image rebuild, matching `COHORT_MATERIALIZE_LIMIT`.

Both settings are passed **per query** via `chQuery(query, settings)` — no server, env, or Cloud configuration changes.

## Also

`buildPropertyBasedCohortQuery` had no callers while `computePropertyBasedCohort` and `countPropertyBasedCohort` each rebuilt the same SQL inline — which is how they drifted. They now share one builder, so preview counts and materialized membership can't diverge.

## Tests

`packages/db/src/services/cohort-property-sql.test.ts` pins the emitted SQL: no `FINAL`, aggregates in `HAVING` not `WHERE`, plain columns wrapped too (so mixed Map + column cohorts stay a single scan), limit applied, and the all-filters-empty case still matching nothing.

- `pnpm test` — **467 passed / 27 files**
- `pnpm typecheck` — clean

Formatter not run, per the repo's CLAUDE.md.

## Not included

`571cccb7` has **77,630** real members but `COHORT_MATERIALIZE_LIMIT` is 10,000, so it will now succeed while storing an arbitrary 13% of its membership. That's a pre-existing cap and a deliberate product call, so it's left alone here — worth deciding separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
