### PR TITLE
fix(funnel): compute View Users from the same query as the chart (NS-13549)

### DIFF
--- a/packages/db/src/services/funnel-sql.test.ts
+++ b/packages/db/src/services/funnel-sql.test.ts
@@ -104,3 +104,79 @@ describe('funnel profile-property scalar rewrite', () => {
     expect(sql).not.toContain('`profile.properties.');
   });
 });
+
+// "View Users" on a funnel step must evaluate the exact same funnel as the
+// chart (NS-13549). The old hand-rolled query in the trpc router selected
+// `profile.properties[...]` for profile-property breakdowns without joining
+// profiles (UNKNOWN_IDENTIFIER → the modal showed "No users found"), and it
+// grouped windowFunnel by the breakdown value, splitting sequences.
+describe('funnel profile ids query (View Users modal)', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubEnv('NEWTON_RESOLVE_PROFILE', '1');
+  });
+
+  const base = {
+    projectId: 'p1',
+    startDate: '2026-06-01 00:00:00',
+    endDate: '2026-06-02 00:00:00',
+    series: eventSeries.map((s) => ({ ...s, type: 'event' as const })),
+    stepIndex: 0,
+    funnelWindow: 0.2,
+    funnelGroup: 'profile_id',
+    timezone: 'UTC',
+  };
+
+  it('joins profiles and rewrites refs for profile-property breakdowns', async () => {
+    const { funnelService } = await import('./funnel.service');
+    const query = await funnelService.buildFunnelProfileIdsQuery({
+      ...base,
+      breakdowns: [{ name: 'profile.properties.experiment' }],
+      breakdownValues: ['control'],
+    });
+    const sql = query.toSQL();
+    expect(sql).toContain('as profile');
+    expect(sql).toContain('`profile.properties.experiment`');
+    expect(sql).not.toContain("profile.properties['experiment']");
+  });
+
+  it('attributes breakdowns at the entry step instead of grouping by them', async () => {
+    const { funnelService } = await import('./funnel.service');
+    const query = await funnelService.buildFunnelProfileIdsQuery({
+      ...base,
+      breakdowns: [{ name: 'properties.experiment' }],
+      breakdownValues: ['control'],
+    });
+    const sql = query.toSQL();
+    expect(sql).toContain('argMinIf(');
+    expect(sql).not.toContain('GROUP BY profile_id, b_0');
+    expect(sql).toContain("trim(b_0) = 'control'");
+  });
+
+  it('filters level >= step for completed and = step for dropoffs', async () => {
+    const { funnelService } = await import('./funnel.service');
+    const completed = (
+      await funnelService.buildFunnelProfileIdsQuery({ ...base, stepIndex: 1 })
+    ).toSQL();
+    expect(completed).toContain('level >= 2');
+    const dropped = (
+      await funnelService.buildFunnelProfileIdsQuery({
+        ...base,
+        stepIndex: 1,
+        showDropoffs: true,
+      })
+    ).toSQL();
+    expect(dropped).toContain('level = 2');
+  });
+
+  it('matches empty raw values when the clicked row is "Not set"', async () => {
+    const { funnelService } = await import('./funnel.service');
+    const query = await funnelService.buildFunnelProfileIdsQuery({
+      ...base,
+      breakdowns: [{ name: 'properties.experiment' }],
+      breakdownValues: ['Not set'],
+    });
+    const sql = query.toSQL();
+    expect(sql).toContain("trim(b_0) = ''");
+  });
+});

--- a/packages/db/src/services/funnel.service.ts
+++ b/packages/db/src/services/funnel.service.ts
@@ -227,32 +227,33 @@ export class FunnelService {
     );
   }
 
-  async getFunnel({
+  /**
+   * Builds the funnel query up to and including the `funnel` CTE.
+   * Shared by getFunnel (the chart) and buildFunnelProfileIdsQuery (the
+   * "View Users" modal) so both always evaluate the exact same funnel:
+   * same breakdown attribution (argMinIf at the entry step), same
+   * profile/cohort/group joins. Any divergence between the two shows up
+   * as "chart says N users, modal says none" (NS-13549).
+   */
+  async buildFunnelQuery({
     projectId,
     startDate,
     endDate,
-    series,
-    options,
+    eventSeries,
     breakdowns = [],
-    limit,
-    timezone = 'UTC',
-  }: IReportInput & { timezone: string; events?: IChartEvent[] }) {
-    if (!startDate || !endDate) {
-      throw new Error('startDate and endDate are required');
-    }
-
-    const funnelOptions = options?.type === 'funnel' ? options : undefined;
-    const funnelWindow = funnelOptions?.funnelWindow ?? 24;
-    const funnelGroup = funnelOptions?.funnelGroup;
-
-    const eventSeries = onlyReportEvents(series);
-
-    if (eventSeries.length === 0) {
-      throw new Error('events are required');
-    }
-
-    const funnelWindowSeconds = funnelWindow * 3600;
-    const funnelWindowMilliseconds = funnelWindowSeconds * 1000;
+    funnelWindowMilliseconds,
+    funnelGroup,
+    timezone,
+  }: {
+    projectId: string;
+    startDate: string;
+    endDate: string;
+    eventSeries: IChartEvent[];
+    breakdowns: { name: string }[];
+    funnelWindowMilliseconds: number;
+    funnelGroup?: string;
+    timezone: string;
+  }) {
     const group = this.getFunnelGroup(funnelGroup);
     const profileFilters = this.getProfileFilters(eventSeries);
     const anyFilterOnProfile = profileFilters.length > 0;
@@ -381,6 +382,44 @@ export class FunnelService {
       'SELECT * FROM session_funnel WHERE level != 0',
     );
 
+    return funnelQuery;
+  }
+
+  async getFunnel({
+    projectId,
+    startDate,
+    endDate,
+    series,
+    options,
+    breakdowns = [],
+    limit,
+    timezone = 'UTC',
+  }: IReportInput & { timezone: string; events?: IChartEvent[] }) {
+    if (!startDate || !endDate) {
+      throw new Error('startDate and endDate are required');
+    }
+
+    const funnelOptions = options?.type === 'funnel' ? options : undefined;
+    const funnelWindow = funnelOptions?.funnelWindow ?? 24;
+    const funnelGroup = funnelOptions?.funnelGroup;
+
+    const eventSeries = onlyReportEvents(series);
+
+    if (eventSeries.length === 0) {
+      throw new Error('events are required');
+    }
+
+    const funnelQuery = await this.buildFunnelQuery({
+      projectId,
+      startDate,
+      endDate,
+      eventSeries,
+      breakdowns,
+      funnelWindowMilliseconds: funnelWindow * 3600 * 1000,
+      funnelGroup,
+      timezone,
+    });
+
     funnelQuery
       .select<{
         level: number;
@@ -480,6 +519,95 @@ export class FunnelService {
         const bTotal = b.steps.reduce((acc, step) => acc + step.count, 0);
         return bTotal - aTotal;
       });
+  }
+
+  /**
+   * Query for the profile ids behind a funnel step ("View Users" modal).
+   * stepIndex is 0-based; completed = level >= step, dropped = level == step.
+   * The clicked breakdown row passes back the DISPLAY labels (trimmed,
+   * empty → EMPTY_BREAKDOWN_LABEL via normalizeBreakdownValue), so values
+   * are matched against the same normalization, not the raw column.
+   */
+  async buildFunnelProfileIdsQuery({
+    projectId,
+    startDate,
+    endDate,
+    series,
+    stepIndex,
+    showDropoffs = false,
+    breakdowns = [],
+    breakdownValues = [],
+    funnelWindow,
+    funnelGroup,
+    timezone,
+    limit = 1000,
+  }: {
+    projectId: string;
+    startDate: string;
+    endDate: string;
+    series: IReportInput['series'];
+    stepIndex: number;
+    showDropoffs?: boolean;
+    breakdowns?: { name: string }[];
+    breakdownValues?: string[];
+    funnelWindow?: number;
+    funnelGroup?: string;
+    timezone: string;
+    limit?: number;
+  }) {
+    const eventSeries = onlyReportEvents(series);
+
+    if (eventSeries.length === 0) {
+      throw new Error('At least one event series is required');
+    }
+
+    const funnelQuery = await this.buildFunnelQuery({
+      projectId,
+      startDate,
+      endDate,
+      eventSeries,
+      breakdowns,
+      funnelWindowMilliseconds: (funnelWindow ?? 24) * 3600 * 1000,
+      funnelGroup,
+      timezone,
+    });
+
+    const targetLevel = stepIndex + 1;
+
+    funnelQuery
+      .select<{ profile_id: string }>(['DISTINCT profile_id'])
+      .from('funnel')
+      .where('level', showDropoffs ? '=' : '>=', targetLevel);
+
+    breakdowns.forEach((_, index) => {
+      const value = breakdownValues[index];
+      if (value === undefined) {
+        return;
+      }
+      if (value === EMPTY_BREAKDOWN_LABEL) {
+        funnelQuery.rawWhere(
+          `(trim(b_${index}) = '' OR trim(b_${index}) = ${sqlstring.escape(EMPTY_BREAKDOWN_LABEL)})`,
+        );
+      } else {
+        funnelQuery.rawWhere(
+          `trim(b_${index}) = ${sqlstring.escape(value)}`,
+        );
+      }
+    });
+
+    // Cap the number of profiles to avoid exceeding ClickHouse
+    // max_query_size when passing the ids to the profiles lookup.
+    funnelQuery.limit(limit);
+
+    return funnelQuery;
+  }
+
+  async getFunnelProfileIds(
+    input: Parameters<FunnelService['buildFunnelProfileIdsQuery']>[0],
+  ): Promise<string[]> {
+    const query = await this.buildFunnelProfileIdsQuery(input);
+    const rows = await query.execute();
+    return rows.map((row) => row.profile_id).filter(Boolean);
   }
 }
 

--- a/packages/trpc/src/routers/chart.ts
+++ b/packages/trpc/src/routers/chart.ts
@@ -27,7 +27,6 @@ import {
   validateShareAccess,
 } from '@openpanel/db';
 import {
-  type IChartEvent,
   zChartSeries,
   zCriteria,
   zRange,
@@ -923,121 +922,29 @@ export const chartRouter = createTRPCRouter({
 
       const { startDate, endDate } = getChartStartEndDate(input, timezone);
 
-      // stepIndex is 0-based, but level is 1-based, so we need level >= stepIndex + 1
-      const targetLevel = stepIndex + 1;
-
-      const eventSeries = onlyReportEvents(series);
-
-      if (eventSeries.length === 0) {
-        throw new Error('At least one event series is required');
-      }
-
-      const funnelWindowSeconds = (funnelWindow || 24) * 3600;
-      const funnelWindowMilliseconds = funnelWindowSeconds * 1000;
-
-      // Get the grouping strategy (profile_id or session_id)
-      const group = funnelService.getFunnelGroup(funnelGroup);
-
-      const anyFilterOnGroup = (eventSeries as IChartEvent[]).some((e) =>
-        e.filters?.some((f) => f.name.startsWith('group.'))
-      );
-      const anyBreakdownOnGroup = breakdowns.some((b) =>
-        b.name.startsWith('group.')
-      );
-      const needsGroupArrayJoin = anyFilterOnGroup || anyBreakdownOnGroup;
-
-      // Breakdown selects/groupBy so we can filter by specific breakdown values
-      const breakdownSelects = breakdowns.map(
-        (b, index) => `${getSelectPropertyKey(b.name, projectId)} as b_${index}`
-      );
-      const breakdownGroupBy = breakdowns.map((_, index) => `b_${index}`);
-
-      // Create funnel CTE using funnel service
-      const funnelCte = funnelService.buildFunnelCte({
+      // Delegate to FunnelService so the profile list is computed from the
+      // exact same funnel query as the chart itself (same breakdown
+      // attribution and profile/cohort joins) — see NS-13549.
+      const ids = await funnelService.getFunnelProfileIds({
         projectId,
         startDate,
         endDate,
-        eventSeries: eventSeries as IChartEvent[],
-        funnelWindowMilliseconds,
+        series,
+        stepIndex,
+        showDropoffs,
+        breakdowns,
+        breakdownValues,
+        funnelWindow,
+        funnelGroup,
         timezone,
-        additionalSelects: breakdownSelects,
-        additionalGroupBy: breakdownGroupBy,
-        group,
       });
 
-      // Check for profile filters and add profile join if needed
-      const profileFilters = funnelService.getProfileFilters(
-        eventSeries as IChartEvent[]
-      );
-      if (profileFilters.length > 0) {
-        const fieldsToSelect = uniq(
-          profileFilters.map((f) => f.split('.')[0])
-        ).join(', ');
-        funnelCte.leftJoin(
-          `(SELECT id, ${fieldsToSelect} FROM ${TABLE_NAMES.profiles} FINAL WHERE project_id = ${sqlstring.escape(projectId)}) as profile`,
-          'profile.id = events.profile_id'
-        );
-      }
-
-      if (needsGroupArrayJoin) {
-        funnelCte.rawJoin('ARRAY JOIN groups AS _group_id');
-        funnelCte.rawJoin('LEFT ANY JOIN _g ON _g.id = _group_id');
-      }
-
-      // Build main query
-      const query = clix(ch, timezone);
-      if (needsGroupArrayJoin) {
-        query.with(
-          '_g',
-          `SELECT id, name, type, properties FROM ${TABLE_NAMES.groups} FINAL WHERE project_id = ${sqlstring.escape(projectId)}`
-        );
-      }
-      query.with('session_funnel', funnelCte);
-
-      if (group === 'profile_id') {
-        const breakdownAggregates =
-          breakdowns.length > 0
-            ? `, ${breakdowns.map((_, index) => `any(b_${index}) AS b_${index}`).join(', ')}`
-            : '';
-        query.with(
-          'funnel',
-          `SELECT profile_id, max(level) AS level${breakdownAggregates} FROM (SELECT * FROM session_funnel WHERE level != 0) GROUP BY profile_id`
-        );
-      } else {
-        query.with('funnel', 'SELECT * FROM session_funnel WHERE level != 0');
-      }
-
-      query.select(['DISTINCT profile_id']).from('funnel');
-
-      if (showDropoffs) {
-        query.where('level', '=', targetLevel);
-      } else {
-        query.where('level', '>=', targetLevel);
-      }
-
-      // Filter by specific breakdown values when a breakdown row was clicked
-      breakdowns.forEach((_, index) => {
-        const value = breakdownValues[index];
-        if (value !== undefined) {
-          query.where(`b_${index}`, '=', value);
-        }
-      });
-
-      // Cap the number of profiles to avoid exceeding ClickHouse max_query_size
-      // when passing IDs to the next query
-      query.limit(1000);
-
-      const profileIdsResult = (await query.execute()) as {
-        profile_id: string;
-      }[];
-
-      if (profileIdsResult.length === 0) {
+      if (ids.length === 0) {
         return [];
       }
 
       // Fetch profile details in batches to avoid exceeding ClickHouse max_query_size
       // when there are many profile IDs to pass in the IN(...) clause
-      const ids = profileIdsResult.map((p) => p.profile_id).filter(Boolean);
       const BATCH_SIZE = 500;
       const profiles: IServiceProfile[] = [];
       for (let i = 0; i < ids.length; i += BATCH_SIZE) {


### PR DESCRIPTION
## Problem

[NS-13549](https://newtonschool.atlassian.net/browse/NS-13549): funnel reports with a **profile-property breakdown** (e.g. "POP on Trial Platform", broken down by `profile.properties.ds_trial_lms_home_information_pop_change_experiment`) show real step counts on the chart, but clicking **View Users** on any step returns "No users found".

## Root cause

`chart.getFunnelProfiles` duplicated the funnel SQL instead of reusing `FunnelService.getFunnel`. The duplicate rendered the breakdown as `profile.properties['…'] as b_0` but only joined `profiles` when the event series had `profile.*` **filters** — never for breakdowns. With no join, ClickHouse fails:

```
Code 47: Unknown expression or function identifier `profile.properties` in scope session_funnel
```

The tRPC call 500s and the modal renders the error state as an empty list (confirmed in prod dashboard-api logs — every `getFunnelProfiles` call for this report fails with error 47). Pre-existing upstream bug (`b4214746` "feat: report editor"); upstream HEAD has the same defect.

Two adjacent defects in the same duplicated query: it still grouped `windowFunnel` by the breakdown value (the sequence-splitting semantics #4 fixed on the chart side, so modal counts could disagree with the chart on event-property breakdowns), and cohort breakdowns would fail the same way (cohort join never added).

## Fix

Stop duplicating the query:

- Extract the funnel CTE construction from `getFunnel` into a shared `buildFunnelQuery` (moved verbatim — chart SQL is unchanged).
- Add `FunnelService.getFunnelProfileIds` on top of it: level filter (`>=` completed / `=` dropped), breakdown-value filters matched against the display normalization (clicked "Not set" rows match empty raw values), 1000-id cap.
- `chart.getFunnelProfiles` now just calls the service and hydrates profiles.

The modal therefore always evaluates the identical funnel as the chart: same profile/cohort/group joins, same entry-step (`argMinIf`) breakdown attribution.

## Testing

- 4 new SQL-shape regression tests in `funnel-sql.test.ts` (profiles join + scalar rewrite for profile-property breakdowns, argMinIf instead of GROUP BY, level semantics, "Not set" matching)
- `pnpm vitest run packages/db packages/trpc`: 48/48 pass; both packages typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Perf

The chart path is byte-identical (verbatim extraction). The new modal query for the NS-13549 report was executed against prod ClickHouse: 1,000 profiles (LIMIT), 9.9s, 22.9M rows / 10.7 GiB read, no OOM — same cost class as the chart's own funnel query for this report (5.5s), because it now runs the identical (narrowed-keys) profiles join. Event-property-breakdown funnels get cheaper (argMinIf replaces GROUP BY b_N + a re-aggregation pass); no-breakdown funnels drop the re-aggregation CTE entirely.
